### PR TITLE
Implement handling of HubSpot error responses

### DIFF
--- a/src/Core/HubSpotBaseClient.cs
+++ b/src/Core/HubSpotBaseClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -125,7 +126,12 @@ namespace Skarp.HubSpotClient.Core
 
             if (!response.IsSuccessStatusCode)
             {
-                throw new NotImplementedException("Deal with non success codes somehow!");
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    return default(T);
+                }
+
+                throw new HubSpotException("Error from HubSpot", responseData);
             }
 
             return deserializeFunc(responseData);

--- a/src/HubSpotException.cs
+++ b/src/HubSpotException.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Skarp.HubSpotClient
+{
+    [Serializable]
+    public class HubSpotException : Exception
+    {
+        public string RawJsonResponse { get; set; }
+        public HubSpotException()
+        {
+        }
+
+        public HubSpotException(string message) : base(message)
+        {
+        }
+
+        public HubSpotException(string message, string jsonResponse) : base(message)
+        {
+            RawJsonResponse = jsonResponse;
+        }
+
+        public HubSpotException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/test/functional/Contact/HubSpotContactClientFunctionalTest.cs
+++ b/test/functional/Contact/HubSpotContactClientFunctionalTest.cs
@@ -25,7 +25,8 @@ namespace Skarp.HubSpotClient.FunctionalTests.Contact
                 .AddTestCase(new CreateContactMockTestCase())
                 .AddTestCase(new ListContactMockTestCase())
                 .AddTestCase(new GetContactMockTestCase())
-                .AddTestCase(new GetContactByEmailMockTestCase());
+                .AddTestCase(new GetContactByEmailMockTestCase())
+                .AddTestCase(new GetContactByEmailNotFoundMockTestCase());
 
             _client = new HubSpotContactClient(
                 mockHttpClient,
@@ -93,6 +94,15 @@ namespace Skarp.HubSpotClient.FunctionalTests.Contact
             Assert.Equal("Codey", data.FirstName);
             Assert.Equal("Huang", data.Lastname);
             Assert.Equal(email, data.Email);
+        }
+
+        [Fact]
+        public async Task ContactClient_returns_null_when_contact_not_found()
+        {
+            const string email = "not@here.com";
+            var data = await _client.GetByEmailAsync<ContactHubSpotEntity>(email);
+
+            Assert.Null(data);
         }
     }
 }

--- a/test/functional/Mocks/Contact/GetContactByEmailMockTestCase.cs
+++ b/test/functional/Mocks/Contact/GetContactByEmailMockTestCase.cs
@@ -10,7 +10,7 @@ namespace Skarp.HubSpotClient.FunctionalTests.Mocks.Contact
     {
         public bool IsMatch(HttpRequestMessage request)
         {
-            return request.RequestUri.AbsolutePath.Contains("/contacts/v1/contact/email/");
+            return request.RequestUri.AbsolutePath.Contains("/contacts/v1/contact/email/testingapis@hubspot.com");
         }
 
         public Task<HttpResponseMessage> GetResponseAsync(HttpRequestMessage request)

--- a/test/functional/Mocks/Contact/GetContactByEmailNotFoundMockTestCase.cs
+++ b/test/functional/Mocks/Contact/GetContactByEmailNotFoundMockTestCase.cs
@@ -1,0 +1,29 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using RapidCore.Network;
+using Skarp.HubSpotClient.Core;
+
+namespace Skarp.HubSpotClient.FunctionalTests.Mocks.Contact
+{
+    public class GetContactByEmailNotFoundMockTestCase : IMockRapidHttpClientTestCase
+    {
+        public bool IsMatch(HttpRequestMessage request)
+        {
+            return request.RequestUri.AbsolutePath.Contains("/contacts/v1/contact/email/not@here.com");
+        }
+
+        public Task<HttpResponseMessage> GetResponseAsync(HttpRequestMessage request)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+
+            const string jsonResponse =
+                "{\"status\":\"error\",\"message\":\"contact does not exist\",\"correlationId\":\"6acf1262-0456-48d8-b0f8-070a698e7d05\",\"requestId\":\"ded0ada067ad2b3ff547f46afd03b9a7\"}";
+            response.Content = new JsonContent(jsonResponse);
+            response.StatusCode = HttpStatusCode.NotFound;
+            response.RequestMessage = request;
+
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
On 404 return `default(T)` - null, and all other errors throw a
HubSpotException with the json response attached.