### PR TITLE
Honor IgnoreDataMember attribute

### DIFF
--- a/src/Core/ReflectionExtensions.cs
+++ b/src/Core/ReflectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reflection;
 using System.Runtime.Serialization;
+using RapidCore.Reflection;
 
 namespace Skarp.HubSpotClient.Core
 {
@@ -59,6 +60,20 @@ namespace Skarp.HubSpotClient.Core
 
             // TODO better bailout exception?
             throw new ArgumentException($"Unable to locate method with name: {name}");
+        }
+
+        /// <summary>
+        /// Determines whether the given property has the <see cref="IgnoreDataMemberAttribute"/>
+        /// </summary>
+        /// <param name="prop">The property.</param>
+        /// <returns>
+        ///   <c>true</c> if [has ignore data member attribute] [the specified property]; otherwise, <c>false</c>.
+        /// </returns>
+        internal static bool HasIgnoreDataMemberAttribute(this PropertyInfo prop)
+        {
+            if (prop == null) return false;
+
+            return prop.HasAttribute(typeof(IgnoreDataMemberAttribute));
         }
     }
 }

--- a/src/Core/Requests/RequestDataConverter.cs
+++ b/src/Core/Requests/RequestDataConverter.cs
@@ -35,9 +35,11 @@ namespace Skarp.HubSpotClient.Core.Requests
 
             foreach (var prop in allProps)
             {
+                if (prop.HasIgnoreDataMemberAttribute()) { continue; }
+
                 var propSerializedName = prop.GetPropSerializedName();
                 _logger.LogDebug("Mapping prop: '{0}' with serialization name: '{1}'", prop.Name, propSerializedName);
-                if (prop.Name.Equals("RouteBasePath")) continue;
+                if (prop.Name.Equals("RouteBasePath")) { continue; }
 
                 var propValue = prop.GetValue(entity);
                 var item = new HubspotDataEntityProp
@@ -51,7 +53,7 @@ namespace Skarp.HubSpotClient.Core.Requests
                     item.Property = null;
                     item.Name = propSerializedName;
                 }
-                if (item.Value == null) continue;
+                if (item.Value == null) { continue; }
 
                 mapped.Properties.Add(item);
             }

--- a/test/unit/Core/ReflectionExtensionTest.cs
+++ b/test/unit/Core/ReflectionExtensionTest.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
+using RapidCore.Reflection;
 using Skarp.HubSpotClient.Contact.Dto;
 using Skarp.HubSpotClient.Core;
 using Xunit;
@@ -31,9 +32,18 @@ namespace Skarp.HubSpotClient.UnitTest.Core
 
             // find the Add(T) method on the List entity!
             var listProp = dto.GetType().GetProperties().Single(p => p.Name == "Contacts");
-            var method = listProp.PropertyType.FindMethodRecursively("Add", new [] {typeof(ContactHubSpotEntity) });
+            var method = listProp.PropertyType.FindMethodRecursively("Add", new[] { typeof(ContactHubSpotEntity) });
 
             Assert.NotNull(method);
+        }
+
+        [Fact]
+        public void ReflectionExtension_can_determine_if_prop_has_ignore_data_member()
+        {
+            var dto = new ClassWithDataMembers();
+            var propWithIgnore = dto.GetType().GetProperties().Single(p => p.Name == "IgnoreMePlease");
+            var hasAttr = propWithIgnore.HasIgnoreDataMemberAttribute();
+            Assert.True(hasAttr);
         }
 
         [DataContract]
@@ -45,6 +55,9 @@ namespace Skarp.HubSpotClient.UnitTest.Core
 
             [DataMember(Name = "CallMeThis")]
             public string MemberWithCustomName { get; set; }
+
+            [IgnoreDataMember]
+            public string IgnoreMePlease { get; set; }
         }
     }
 }

--- a/test/unit/Core/Requests/RequestDataConverterTest.cs
+++ b/test/unit/Core/Requests/RequestDataConverterTest.cs
@@ -1,5 +1,6 @@
 ﻿using System.Dynamic;
 using System.Linq;
+using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Skarp.HubSpotClient.Company.Dto;
 using Skarp.HubSpotClient.Contact.Dto;
@@ -45,7 +46,8 @@ namespace Skarp.HubSpotClient.UnitTest.Core.Requests
                 State = "MA",
                 Website = "http://hubspot.com",
                 ZipCode = "02139",
-                MyCustomProp = "Has a value!"
+                MyCustomProp = "Has a value!",
+                IgnoreMe = "Even though I have a value! muhahahah"
             };
 
             _companyDto = new CompanyHubSpotEntity
@@ -149,8 +151,9 @@ namespace Skarp.HubSpotClient.UnitTest.Core.Requests
         private class CustomContactHubSpotEntity : ContactHubSpotEntity
         {
             public string MyCustomProp { get; set; }
-        }
 
-       
+            [IgnoreDataMember]
+            public string IgnoreMe { get; set; }
+        }
     }
 }


### PR DESCRIPTION
When a property in a DTO is decorated with the `IgnoreDataMember` we shall not send it to HubSpot.

