### PR TITLE
Added CRUD implementation for Deal API

### DIFF
--- a/src/Core/Requests/RequestDataConverter.cs
+++ b/src/Core/Requests/RequestDataConverter.cs
@@ -176,6 +176,14 @@ namespace Skarp.HubSpotClient.Core.Requests
                 vidProp?.SetValue(dto, vidData);
             }
 
+            // The dealId is the "id" of the deal entity
+            if (expandoDict.TryGetValue("dealId", out var dealIdData))
+            {
+                // TODO use properly serialized name of prop to find it
+                var dealIdProp = dtoProps.SingleOrDefault(q => q.GetPropSerializedName() == "dealId");
+                dealIdProp?.SetValue(dto, dealIdData);
+            }
+
             // The Properties object in the json / response data contains all the props we wish to map - if that does not exist
             // we cannot proceeed
             if (!expandoDict.TryGetValue("properties", out var dynamicProperties)) return dto;

--- a/src/Deal/Dto/DealHubSpotEntity.cs
+++ b/src/Deal/Dto/DealHubSpotEntity.cs
@@ -1,0 +1,36 @@
+﻿using Skarp.HubSpotClient.Deal.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Skarp.HubSpotClient.Deal.Dto
+{
+    
+    [DataContract]
+    public class DealHubSpotEntity : IDealHubSpotEntity
+    {
+        /// <summary>
+        /// Contacts unique Id in HubSpot
+        /// </summary>
+        [DataMember(Name = "dealId")]
+        [IgnoreDataMember]
+        public long? Id { get; set; }
+        [DataMember(Name = "dealname")]
+        public string Name { get; set; }
+        [DataMember(Name = "dealstage")]
+        public string Stage { get; set; }
+        [DataMember(Name = "pipeline")]
+        public string Pipeline { get; set; }
+        [DataMember(Name = "hubspot_owner_id")]
+        public string OwnerId { get; set; }
+        [DataMember(Name = "closedate")]
+        public string CloseDate { get; set; }
+        [DataMember(Name = "amount")]
+        public string Amount { get; set; }
+        [DataMember(Name = "dealtype")]
+        public string DealType { get; set; }
+
+        public string RouteBasePath => "/deals/v1";
+    }
+}

--- a/src/Deal/HubSpotDealClient.cs
+++ b/src/Deal/HubSpotDealClient.cs
@@ -1,0 +1,131 @@
+﻿using Microsoft.Extensions.Logging;
+using RapidCore.Network;
+using Skarp.HubSpotClient.Core;
+using Skarp.HubSpotClient.Core.Interfaces;
+using Skarp.HubSpotClient.Core.Requests;
+using Skarp.HubSpotClient.Deal.Dto;
+using Skarp.HubSpotClient.Deal.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Skarp.HubSpotClient.Deal
+{
+    public class HubSpotDealClient : HubSpotBaseClient
+    {
+        /// <summary>
+        /// Mockable and container ready constructor
+        /// </summary>
+        /// <param name="httpClient"></param>
+        /// <param name="logger"></param>
+        /// <param name="serializer"></param>
+        /// <param name="hubSpotBaseUrl"></param>
+        /// <param name="apiKey"></param>
+        public HubSpotDealClient(
+            IRapidHttpClient httpClient,
+            ILogger<HubSpotDealClient> logger,
+            RequestSerializer serializer,
+            string hubSpotBaseUrl,
+            string apiKey)
+            : base(httpClient, logger, serializer, hubSpotBaseUrl, apiKey)
+        {
+        }
+
+        /// <summary>
+        /// Create a new instance of the HubSpotDealClient with default dependencies
+        /// </summary>
+        /// <remarks>
+        /// This constructor creates a HubSpotDealClient using "real" dependencies that will send requests 
+        /// via the network - if you wish to have support for functional tests and mocking use the "eager" constructor
+        /// that takes in all underlying dependecies
+        /// </remarks>
+        /// <param name="apiKey">Your API key</param>
+        public HubSpotDealClient(string apiKey)
+        : base(
+              new RealRapidHttpClient(new HttpClient()),
+              NoopLoggerFactory.Get(),
+              new RequestSerializer(new RequestDataConverter(NoopLoggerFactory.Get<RequestDataConverter>())),
+              "https://api.hubapi.com",
+              apiKey)
+        { }
+
+        /// <summary>
+        /// Creates the deal entity asyncrhounously.
+        /// </summary>
+        /// <param name="entity">The entity.</param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
+        public async Task<T> CreateAsync<T>(IDealHubSpotEntity entity) where T : IHubSpotEntity, new()
+        {
+            Logger.LogDebug("Deal CreateAsync");
+            var path = PathResolver(entity, HubSpotAction.Create);
+            var data = await PostAsync<T>(path, entity);
+            return data;
+        }
+
+        /// <summary>
+        /// Return a single deal by id from hubspot
+        /// </summary>
+        /// <param name="dealId"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public async Task<T> GetByIdAsync<T>(long dealId) where T : IHubSpotEntity, new()
+        {
+            Logger.LogDebug("Deal Get by id ");
+            var path = PathResolver(new DealHubSpotEntity(), HubSpotAction.Get)
+                .Replace(":dealId:", dealId.ToString());
+            var data = await GetAsync<T>(path);
+            return data;
+        }
+
+        public async Task<T> UpdateAsync<T>(IDealHubSpotEntity entity) where T : IHubSpotEntity, new()
+        {
+            Logger.LogDebug("Deal update w. id: {0}", entity.Id);
+            if (entity.Id < 1)
+            {
+                throw new ArgumentException("Deal entity must have an id set!");
+            }
+            var path = PathResolver(entity, HubSpotAction.Update)
+                .Replace(":dealId:", entity.Id.ToString());
+
+            var data = await PostAsync<T>(path, entity);
+            return data;
+        }
+
+        public async Task DeleteAsync(long dealId)
+        {
+            Logger.LogDebug("Deal delete w. id: {0}", dealId);
+
+            var path = PathResolver(new DealHubSpotEntity(), HubSpotAction.Delete)
+                .Replace(":dealId:", dealId.ToString());
+
+            await DeleteAsync<DealHubSpotEntity>(path);
+        }
+
+        /// <summary>
+        /// Resolve a hubspot API path based off the entity and opreation that is about to happen
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <param name="action"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        public string PathResolver(IHubSpotEntity entity, HubSpotAction action)
+        {
+            switch (action)
+            {
+                case HubSpotAction.Create:
+                    return $"{entity.RouteBasePath}/deal";
+                case HubSpotAction.Get:
+                    return $"{entity.RouteBasePath}/deal/:dealId:";
+                case HubSpotAction.Update:
+                    return $"{entity.RouteBasePath}/deal/:dealId:";
+                case HubSpotAction.Delete:
+                    return $"{entity.RouteBasePath}/deal/:dealId:";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(action), action, null);
+            }
+        }
+    }
+}

--- a/src/Deal/Interfaces/IDealHubSpotEntity.cs
+++ b/src/Deal/Interfaces/IDealHubSpotEntity.cs
@@ -1,0 +1,16 @@
+﻿using Skarp.HubSpotClient.Core.Interfaces;
+
+namespace Skarp.HubSpotClient.Deal.Interfaces
+{
+    public interface IDealHubSpotEntity : IHubSpotEntity
+    {
+        long? Id { get; set; }
+        string Name { get; set; }
+        string Stage { get; set; }
+        string Pipeline { get; set; }
+        string OwnerId { get; set; }
+        string CloseDate { get; set; }
+        string Amount { get; set; }
+        string DealType { get; set; }
+    }
+}

--- a/src/hubspot-client.csproj
+++ b/src/hubspot-client.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="RapidCore" Version="0.14.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
     <DotNetCliToolReference Include="dotnet-version-cli" Version="0.4.1" />
   </ItemGroup>
 </Project>

--- a/src/hubspot-client.csproj
+++ b/src/hubspot-client.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
     <Version>0.1.1</Version>
@@ -21,6 +21,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="RapidCore" Version="0.14.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+    <PackageReference Include="xunit" Version="2.2.0" />
     <DotNetCliToolReference Include="dotnet-version-cli" Version="0.4.1" />
   </ItemGroup>
 </Project>

--- a/test/functional/Deal/HubSpotDealClientFunctionalTest.cs
+++ b/test/functional/Deal/HubSpotDealClientFunctionalTest.cs
@@ -1,0 +1,99 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using RapidCore.Network;
+using Skarp.HubSpotClient.Deal;
+using Skarp.HubSpotClient.Deal.Dto;
+using Skarp.HubSpotClient.Core.Requests;
+using Xunit;
+using Xunit.Abstractions;
+using Skarp.HubSpotClient.FunctionalTests.Mocks.Deal;
+
+namespace Skarp.HubSpotClient.FunctionalTests.Deal
+{
+    public class HubSpotDealClientFunctionalTest : FunctionalTestBase<HubSpotDealClient>
+    {
+        private readonly HubSpotDealClient _client;
+
+        public HubSpotDealClientFunctionalTest(ITestOutputHelper output)
+            : base(output)
+        {
+            var mockHttpClient = new MockRapidHttpClient()
+                .AddTestCase(new CreateDealMockTestCase())
+                .AddTestCase(new GetDealMockTestCase())
+                .AddTestCase(new GetDealByIdNotFoundMockTestCase())
+                .AddTestCase(new UpdateDealMockTestCase())
+                .AddTestCase(new DeleteDealMockTestCase());
+
+            _client = new HubSpotDealClient(
+                mockHttpClient,
+                Logger,
+                new RequestSerializer(new RequestDataConverter(LoggerFactory.CreateLogger<RequestDataConverter>())),
+                "https://api.hubapi.com/",
+                "HapiKeyFisk"
+            );
+        }
+
+        [Fact]
+        public async Task DealClient_can_create_Deals()
+        {
+            var data = await _client.CreateAsync<DealHubSpotEntity>(new DealHubSpotEntity
+            {
+                Name = "A new deal",
+                Pipeline = "default",
+                Amount = "60000",
+                DealType = "newbusiness"
+            });
+
+            Assert.NotNull(data);
+
+            // Should have replied with mocked data, so it does not really correspond to our input data, but it proves the "flow"
+            Assert.Equal(151088, data.Id);
+        }
+
+        [Fact]
+        public async Task DealClient_can_get_Deal()
+        {
+            const int dealId = 151088;
+            var data = await _client.GetByIdAsync<DealHubSpotEntity>(dealId);
+
+            Assert.NotNull(data);
+            Assert.Equal("This is a Deal", data.Name);
+            Assert.Equal("560", data.Amount);
+            Assert.Equal(dealId, data.Id);
+        }
+
+
+        [Fact]
+        public async Task DealClient_returns_null_when_Deal_not_found()
+        {
+            const int dealId = 158;
+            var data = await _client.GetByIdAsync<DealHubSpotEntity>(dealId);
+
+            Assert.Null(data);
+        }
+
+        [Fact]
+        public async Task DealClient_update_Deal_works()
+        {
+            var data = await _client.UpdateAsync<DealHubSpotEntity>(new DealHubSpotEntity
+            {
+                Id = 151088,
+                Name = "This is an updated deal",
+                Amount = "560"
+            }
+            );
+
+            Assert.NotNull(data);
+
+            // Should have replied with mocked data, so it does not really correspond to our input data, but it proves the "flow"
+            Assert.Equal("560", data.Amount);
+            Assert.Equal(151088, data.Id);
+        }
+
+        [Fact]
+        public async Task DealClient_delete_Deal_works()
+        {
+            await _client.DeleteAsync(151088);
+        }
+    }
+}

--- a/test/functional/Mocks/Deal/CreateDealMockTestCase.cs
+++ b/test/functional/Mocks/Deal/CreateDealMockTestCase.cs
@@ -1,0 +1,27 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using RapidCore.Network;
+using Skarp.HubSpotClient.Core;
+
+namespace Skarp.HubSpotClient.FunctionalTests.Mocks.Deal
+{
+    public class CreateDealMockTestCase : IMockRapidHttpClientTestCase
+    {
+        public bool IsMatch(HttpRequestMessage request)
+        {
+            return request.RequestUri.AbsolutePath.EndsWith("/deals/v1/deal");
+        }
+
+        public Task<HttpResponseMessage> GetResponseAsync(HttpRequestMessage request)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+
+            const string jsonResponse = "{'portalId': 62515,'dealId': 151088,'isDeleted': false,'associations': {'associatedVids': [27136],'associatedCompanyIds': [8954037],'associatedDealIds': []},'properties': {'amount': {'value': '60000','timestamp': 1410381338943,'source': 'API','sourceId': null,'versions': [{'name': 'amount','value': '60000','timestamp': 1410381338943,'source': 'API', 'sourceVid': []}]},'dealstage': {'value': 'appointmentscheduled','timestamp': 1410381338943,'source': 'API','sourceId': null,'versions': [{'name': 'dealstage','value': 'appointmentscheduled','timestamp': 1410381338943,'source': 'API','sourceVid': []}]},'pipeline': {'value': 'default','timestamp': 1410381338943,'source': 'API', 'sourceId': null,'versions': [{'name': 'pipeline','value': 'default','timestamp': 1410381338943,'source': 'API','sourceVid': []}]},'closedate': {'value': '1409443200000','timestamp': 1410381338943,'source': 'API','sourceId': null,'versions': [{'name': 'closedate','value': '1409443200000','timestamp': 1410381338943,'source': 'API', 'sourceVid': []}]},'createdate': {'value': '1410381339020','timestamp': 1410381339020,'source': null,'sourceId': null,'versions': [{'name': 'createdate','value': '1410381339020','timestamp': 1410381339020,'sourceVid': []}]},'hubspot_owner_id': {'value': '24','timestamp': 1410381338943,'source': 'API','sourceId': null,'versions': [{'name': 'hubspot_owner_id','value': '24','timestamp': 1410381338943,'source': 'API', 'sourceVid': []}]},'hs_createdate': {'value': '1410381339020','timestamp': 1410381339020,'source': null,'sourceId': null,'versions': [{'name': 'hs_createdate','value': '1410381339020','timestamp': 1410381339020,'sourceVid': []}]},'dealtype': {'value': 'newbusiness','timestamp': 1410381338943,'source': 'API','sourceId': null,'versions': [{'name': 'dealtype','value': 'newbusiness','timestamp': 1410381338943,'source': 'API', 'sourceVid': []}]},'dealname': {'value': 'A new Deal','timestamp': 1410381338943,'source': 'API','sourceId': null,'versions': [{'name': 'dealname','value': 'A new Deal','timestamp': 1410381338943,'source': 'API','sourceVid': []}]}}}"; 
+            response.Content = new JsonContent(jsonResponse);
+            response.RequestMessage = request;
+
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/test/functional/Mocks/Deal/DeleteDealMockTestCase.cs
+++ b/test/functional/Mocks/Deal/DeleteDealMockTestCase.cs
@@ -1,0 +1,30 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using RapidCore.Network;
+using Skarp.HubSpotClient.Core;
+
+namespace Skarp.HubSpotClient.FunctionalTests.Mocks.Deal
+{
+    public class DeleteDealMockTestCase : IMockRapidHttpClientTestCase
+    {
+        public bool IsMatch(HttpRequestMessage request)
+        {
+            return request.RequestUri.AbsolutePath.Contains("deals/v1/deal/151088") && request.Method == HttpMethod.Delete;
+        }
+
+        public Task<HttpResponseMessage> GetResponseAsync(HttpRequestMessage request)
+        {
+            const string jsonResponse = "";
+
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new JsonContent(jsonResponse),
+                StatusCode = HttpStatusCode.NoContent,
+                RequestMessage = request
+            };
+
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/test/functional/Mocks/Deal/GetDealByIdNotFoundMockTestCase.cs
+++ b/test/functional/Mocks/Deal/GetDealByIdNotFoundMockTestCase.cs
@@ -1,0 +1,29 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using RapidCore.Network;
+using Skarp.HubSpotClient.Core;
+
+namespace Skarp.HubSpotClient.FunctionalTests.Mocks.Deal
+{
+    public class GetDealByIdNotFoundMockTestCase : IMockRapidHttpClientTestCase
+    {
+        public bool IsMatch(HttpRequestMessage request)
+        {
+            return request.RequestUri.AbsolutePath.Contains("/deals/v1/deal/158") && request.Method == HttpMethod.Get;
+        }
+
+        public Task<HttpResponseMessage> GetResponseAsync(HttpRequestMessage request)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+
+            const string jsonResponse =
+                "{'status':'error','message':'Deal does not exist','correlationId':'44f0d1e5-d6d8-4bc5-9b1b-51e5064e206f','requestId':'e3efb55b4250d72680f290f22bdf423e'}";
+            response.Content = new JsonContent(jsonResponse);
+            response.StatusCode = HttpStatusCode.NotFound;
+            response.RequestMessage = request;
+
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/test/functional/Mocks/Deal/GetDealMockTestCase.cs
+++ b/test/functional/Mocks/Deal/GetDealMockTestCase.cs
@@ -1,0 +1,28 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using RapidCore.Network;
+using Skarp.HubSpotClient.Core;
+
+namespace Skarp.HubSpotClient.FunctionalTests.Mocks.Deal
+{
+    public class GetDealMockTestCase : IMockRapidHttpClientTestCase
+    {
+        public bool IsMatch(HttpRequestMessage request)
+        {
+            return request.RequestUri.AbsolutePath.Contains("/deals/v1/deal/151088") && request.Method == HttpMethod.Get;
+        }
+
+        public Task<HttpResponseMessage> GetResponseAsync(HttpRequestMessage request)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+
+            const string jsonResponse = "{'portalId': 62515,'dealId': 151088,'isDeleted': false,'associations': {'associatedVids': [27136],'associatedCompanyIds': [8954037],'associatedDealIds': []},'properties': {'amount': {'value': '560','timestamp': 1410381338943,'source': 'API','sourceId': null,'versions': [{'name': 'amount','value': '560','timestamp': 1410381338943,'source': 'API', 'sourceVid': []}]},'dealstage': {'value': 'appointmentscheduled','timestamp': 1410381338943,'source': 'API','sourceId': null,'versions': [{'name': 'dealstage','value': 'appointmentscheduled','timestamp': 1410381338943,'source': 'API','sourceVid': []}]},'pipeline': {'value': 'default','timestamp': 1410381338943,'source': 'API', 'sourceId': null,'versions': [{'name': 'pipeline','value': 'default','timestamp': 1410381338943,'source': 'API','sourceVid': []}]},'closedate': {'value': '1409443200000','timestamp': 1410381338943,'source': 'API','sourceId': null,'versions': [{'name': 'closedate','value': '1409443200000','timestamp': 1410381338943,'source': 'API', 'sourceVid': []}]},'createdate': {'value': '1410381339020','timestamp': 1410381339020,'source': null,'sourceId': null,'versions': [{'name': 'createdate','value': '1410381339020','timestamp': 1410381339020,'sourceVid': []}]},'hubspot_owner_id': {'value': '24','timestamp': 1410381338943,'source': 'API','sourceId': null,'versions': [{'name': 'hubspot_owner_id','value': '24','timestamp': 1410381338943,'source': 'API', 'sourceVid': []}]},'hs_createdate': {'value': '1410381339020','timestamp': 1410381339020,'source': null,'sourceId': null,'versions': [{'name': 'hs_createdate','value': '1410381339020','timestamp': 1410381339020,'sourceVid': []}]},'dealtype': {'value': 'newbusiness','timestamp': 1410381338943,'source': 'API','sourceId': null,'versions': [{'name': 'dealtype','value': 'newbusiness','timestamp': 1410381338943,'source': 'API', 'sourceVid': []}]},'dealname': {'value': 'This is a Deal','timestamp': 1410381338943,'source': 'API','sourceId': null,'versions': [{'name': 'dealname','value': 'This is a Deal','timestamp': 1410381338943,'source': 'API','sourceVid': []}]}}}";
+
+            response.Content = new JsonContent(jsonResponse);
+            response.RequestMessage = request;
+
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/test/functional/Mocks/Deal/UpdateDealMockTestCase.cs
+++ b/test/functional/Mocks/Deal/UpdateDealMockTestCase.cs
@@ -1,0 +1,27 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using RapidCore.Network;
+using Skarp.HubSpotClient.Core;
+
+namespace Skarp.HubSpotClient.FunctionalTests.Mocks.Deal
+{
+    public class UpdateDealMockTestCase : IMockRapidHttpClientTestCase
+    {
+        public bool IsMatch(HttpRequestMessage request)
+        {
+            return request.RequestUri.AbsolutePath.Contains("deals/v1/deal/151088") && request.Method == HttpMethod.Post;
+        }
+
+        public Task<HttpResponseMessage> GetResponseAsync(HttpRequestMessage request)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+
+            const string jsonResponse = "{'portalId': 62515,'dealId': 151088,'isDeleted': false,'associations': null,'properties': {'amount': {'value': '560','timestamp': 1459873345256,'source': 'API','sourceId': null,'versions': [{'name': 'amount','value': '560','timestamp': 1459873345256,'source': 'API','sourceVid': []}]},'hs_lastmodifieddate': {'value': '1459873345260','timestamp': 1459873345260,'source': 'CALCULATED','sourceId': null,'versions': [{'name': 'hs_lastmodifieddate','value': '1459873345260','timestamp': 1459873345260,'source': 'CALCULATED','sourceVid': []}]}},'imports': []}";
+            response.Content = new JsonContent(jsonResponse);
+            response.RequestMessage = request;
+
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/test/unit/Deal/HubSpotDealClientTest.cs
+++ b/test/unit/Deal/HubSpotDealClientTest.cs
@@ -1,0 +1,82 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FakeItEasy;
+using RapidCore.Network;
+using Skarp.HubSpotClient.Core;
+using Skarp.HubSpotClient.Core.Interfaces;
+using Skarp.HubSpotClient.Core.Requests;
+using Xunit;
+using Xunit.Abstractions;
+using Skarp.HubSpotClient.Deal;
+using Skarp.HubSpotClient.Deal.Dto;
+
+namespace Skarp.HubSpotClient.UnitTest.Contact
+{
+    public class HubSpotDealClientTest : UnitTestBase<HubSpotDealClient>
+    {
+        private readonly HubSpotDealClient _client;
+        private IRapidHttpClient _mockHttpClient;
+        private RequestSerializer _mockSerializer;
+
+        public HubSpotDealClientTest(ITestOutputHelper output) : base(output)
+        {
+            _mockHttpClient = A.Fake<IRapidHttpClient>(opts => opts.Strict());
+
+            A.CallTo(() => _mockHttpClient.SendAsync(A<HttpRequestMessage>.Ignored))
+                .Returns(Task.FromResult(CreateNewEmptyOkResponse()));
+
+            _mockSerializer = A.Fake<RequestSerializer>(opts => opts.Strict());
+            A.CallTo(() => _mockSerializer.SerializeEntity(A<DealHubSpotEntity>.Ignored))
+                .Returns("{}");
+
+            A.CallTo(() => _mockSerializer.DeserializeEntity<DealHubSpotEntity>(A<string>.Ignored))
+                .Returns(new DealHubSpotEntity());
+
+            _client = new HubSpotDealClient(
+                _mockHttpClient,
+                Logger,
+                _mockSerializer,
+                "https://api.hubapi.com",
+                "HapiKeyFisk"
+                );
+        }
+
+        private HttpResponseMessage CreateNewEmptyOkResponse()
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new JsonContent("{}")
+            };
+            return response;
+        }
+
+        [Theory]
+        [InlineData(HubSpotAction.Create, "/deals/v1/deal")]
+        [InlineData(HubSpotAction.Get, "/deals/v1/deal/:dealId:")]
+        [InlineData(HubSpotAction.Update, "/deals/v1/deal/:dealId:")]
+        [InlineData(HubSpotAction.Delete, "/deals/v1/deal/:dealId:")]
+        public void DealClient_path_resolver_works(HubSpotAction action, string expetedPath)
+        {
+            var resvoledPath = _client.PathResolver(new DealHubSpotEntity(), action);
+            Assert.Equal(expetedPath, resvoledPath);
+        }
+
+        [Fact]
+        public async Task DealClient_create_contact_work()
+        {
+            var response = await _client.CreateAsync<DealHubSpotEntity>(new DealHubSpotEntity
+            {
+                Name = "A new deal",
+                Pipeline = "default",
+                Amount = "60000",
+                DealType = "newbusiness"
+            });
+
+            A.CallTo(() => _mockHttpClient.SendAsync(A<HttpRequestMessage>.Ignored)).MustHaveHappened();
+            A.CallTo(() => _mockSerializer.SerializeEntity(A<IHubSpotEntity>.Ignored)).MustHaveHappened();
+            A.CallTo(() => _mockSerializer.DeserializeEntity<DealHubSpotEntity>("{}")).MustHaveHappened();
+        }
+
+    }
+}


### PR DESCRIPTION
This includes unit and functional tests.

Additionally this Deserializer now accepts the dealId as a root value for Id.