### PR TITLE
Serialization and deserialization optimizations + company search

### DIFF
--- a/src/Company/CompanyListRequestOptions.cs
+++ b/src/Company/CompanyListRequestOptions.cs
@@ -7,7 +7,7 @@ using System.Text;
 namespace Skarp.HubSpotClient.Company
 {
     [DataContract]
-    public class CompanySearchByDomain : IHubSpotEntity
+    public class CompanySearchByDomain
     {
         [DataMember(Name = "limit")]
         public int Limit { get; set; } = 100;

--- a/src/Company/Dto/CompanySearchResultEntity.cs
+++ b/src/Company/Dto/CompanySearchResultEntity.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+using Skarp.HubSpotClient.Company.Interfaces;
+using Skarp.HubSpotClient.Contact.Interfaces;
+
+namespace Skarp.HubSpotClient.Company.Dto
+{
+    [DataContract]
+    public class CompanySearchResultEntity<T> : ICompanySearchResultEntity<T> where T : ICompanyHubSpotEntity
+    {
+        [DataMember(Name = "results")]
+        public IList<T> Results { get; set; }
+
+        [DataMember(Name = "hasMore")]
+        public bool MoreResultsAvailable { get; set; }
+
+        [DataMember(Name="offset")]
+        public CompanySearchOffset Offset { get; set; }
+
+        public bool IsNameValue => false;
+
+        public void AcceptHubSpotDataEntity(ref dynamic dataEntity)
+        {
+        }
+    }
+}

--- a/src/Company/HubSpotCompanyClient.cs
+++ b/src/Company/HubSpotCompanyClient.cs
@@ -129,7 +129,7 @@ namespace Skarp.HubSpotClient.Company
         /// <param name="action"></param>
         /// <returns></returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public string PathResolver(IHubSpotEntity entity, HubSpotAction action)
+        public string PathResolver(ICompanyHubSpotEntity entity, HubSpotAction action)
         {
             switch (action)
             {

--- a/src/Company/HubSpotCompanyClient.cs
+++ b/src/Company/HubSpotCompanyClient.cs
@@ -94,7 +94,7 @@ namespace Skarp.HubSpotClient.Company
 
             var path = PathResolver(new CompanyHubSpotEntity(), HubSpotAction.GetByEmail)
                 .Replace(":domain:", email.Substring(email.IndexOf("@")+1));
-            var data = await PostAsync<T>(path, opts);
+            var data = await ListAsPostAsync<T>(path, opts);
             return data;
         }
 

--- a/src/Company/Interfaces/ICompanyHubSpotEntity.cs
+++ b/src/Company/Interfaces/ICompanyHubSpotEntity.cs
@@ -9,5 +9,6 @@ namespace Skarp.HubSpotClient.Company.Interfaces
         string Domain { get; set; }
         string Website { get; set; }
         string Description { get; set; }
+        string RouteBasePath { get; }
     }
 }

--- a/src/Company/Interfaces/ICompanySearchResultEntity.cs
+++ b/src/Company/Interfaces/ICompanySearchResultEntity.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Skarp.HubSpotClient.Core.Interfaces;
+
+namespace Skarp.HubSpotClient.Company.Interfaces
+{
+    public interface ICompanySearchResultEntity<T> : IHubSpotEntity where T : ICompanyHubSpotEntity
+    {
+        IList<T> Results { get; set; }
+
+        bool MoreResultsAvailable { get; set; }
+
+        CompanySearchOffset Offset { get; set; }
+    }
+}

--- a/src/Contact/HubSpotContactClient.cs
+++ b/src/Contact/HubSpotContactClient.cs
@@ -106,7 +106,7 @@ namespace Skarp.HubSpotClient.Contact
             {
                 opts = new ContactListRequestOptions();
             }
-            var path = PathResolver(new ContactListHubSpotEntity<ContactHubSpotEntity>(), HubSpotAction.List) +
+            var path = PathResolver(new ContactHubSpotEntity(), HubSpotAction.List) +
                        $"&count={opts.NumberOfContactsToReturn}";
             if (opts.ContactOffset.HasValue)
             {
@@ -147,7 +147,7 @@ namespace Skarp.HubSpotClient.Contact
         /// <param name="action"></param>
         /// <returns></returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public string PathResolver(IHubSpotEntity entity, HubSpotAction action)
+        public string PathResolver(IContactHubSpotEntity entity, HubSpotAction action)
         {
             switch (action)
             {

--- a/src/Contact/Interfaces/IContactHubSpotEntity.cs
+++ b/src/Contact/Interfaces/IContactHubSpotEntity.cs
@@ -15,5 +15,6 @@ namespace Skarp.HubSpotClient.Contact.Interfaces
         string City { get; set; }
         string State { get; set; }
         string ZipCode { get; set; }
+        string RouteBasePath { get; }
     }
 }

--- a/src/Contact/Interfaces/IContactListHubSpotEntity.cs
+++ b/src/Contact/Interfaces/IContactListHubSpotEntity.cs
@@ -34,5 +34,7 @@ namespace Skarp.HubSpotClient.Contact.Interfaces
         /// The continuation offset.
         /// </value>
         long ContinuationOffset { get; set; }
+
+        string RouteBasePath { get; }
     }
 }

--- a/src/Core/HubSpotBaseClient.cs
+++ b/src/Core/HubSpotBaseClient.cs
@@ -75,6 +75,28 @@ namespace Skarp.HubSpotClient.Core
         }
 
         /// <summary>
+        /// Send a "list" request / search request but using POST so that a body can be sent along
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="absoluteUriPath"></param>
+        /// <returns></returns>
+        protected async Task<T> ListAsPostAsync<T>(string absoluteUriPath, object entity) where T : IHubSpotEntity, new()
+        {
+            Logger.LogDebug("List async for uri path: '{0}'", absoluteUriPath);
+            var json = _serializer.SerializeEntity(entity);
+
+            var httpMethod = HttpMethod.Post;
+
+            var data = await SendRequestAsync<T>(
+                absoluteUriPath,
+                httpMethod,
+                json,
+                responseData => (T)_serializer.DeserializeListEntity<T>(responseData));
+
+            return data;
+        }
+
+        /// <summary>
         /// Send a get request
         /// </summary>
         /// <param name="absoluteUriPath"></param>

--- a/src/Core/Interfaces/IHubSpotEntity.cs
+++ b/src/Core/Interfaces/IHubSpotEntity.cs
@@ -2,14 +2,6 @@
 {
     public interface IHubSpotEntity
     {
-
-        /// <summary>
-        /// When implemented in a downstream class it should return the HubSpot route that the entity belongs to,
-        /// e.g /companies/v2/companies/
-        /// </summary>
-        /// <returns></returns>
-        string RouteBasePath { get;  }
-
         bool IsNameValue { get; }
 
         void AcceptHubSpotDataEntity(ref dynamic dataEntity);

--- a/src/Core/ReflectionExtensions.cs
+++ b/src/Core/ReflectionExtensions.cs
@@ -75,5 +75,23 @@ namespace Skarp.HubSpotClient.Core
 
             return prop.HasAttribute(typeof(IgnoreDataMemberAttribute));
         }
+
+        /// <summary>
+        /// Determines whether the given <param name="instance"></param> is a complex type or a simple ValueType
+        /// </summary>
+        /// <param name="instance">The type.</param>
+        /// <returns>
+        ///   <c>true</c> if [is complex type] [the specified type]; otherwise, <c>false</c>.
+        /// </returns>
+        internal static bool IsComplexType(this Object instance)
+        {
+            if (instance == null) return false;
+
+            var type = instance.GetType();
+            if (type.GetTypeInfo().IsSubclassOf(typeof(ValueType)) || type == (typeof(string)))
+                return false;
+
+            return true;
+        }
     }
 }

--- a/src/Core/ReflectionExtensions.cs
+++ b/src/Core/ReflectionExtensions.cs
@@ -88,6 +88,18 @@ namespace Skarp.HubSpotClient.Core
             if (instance == null) return false;
 
             var type = instance.GetType();
+            return type.IsComplexType();
+        }
+
+        /// <summary>
+        /// Determines whether [is complex type].
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>
+        ///   <c>true</c> if [is complex type] [the specified type]; otherwise, <c>false</c>.
+        /// </returns>
+        internal static bool IsComplexType(this Type type)
+        {
             if (type.GetTypeInfo().IsSubclassOf(typeof(ValueType)) || type == (typeof(string)))
                 return false;
 

--- a/src/Core/Requests/HubspotDataEntityProp.cs
+++ b/src/Core/Requests/HubspotDataEntityProp.cs
@@ -22,7 +22,7 @@
         /// <value>
         /// The value.
         /// </value>
-        public string Value { get; set; }
+        public object Value { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the property that has a value.

--- a/src/Core/Requests/RequestDataConverter.cs
+++ b/src/Core/Requests/RequestDataConverter.cs
@@ -143,7 +143,18 @@ namespace Skarp.HubSpotClient.Core.Requests
                     continue;
                 }
                 // we have a property which name serializes to the kvp.Key, let's set the data
-                theProp.SetValue(data, kvp.Value);
+
+                // If theProp is a complex type we cannot just use SetValue, we need a conversion
+                if (theProp.PropertyType.IsComplexType())
+                {
+                    var expandoEntry = kvp.Value as ExpandoObject;
+                    var dto = ConvertSingleEntity(expandoEntry, Activator.CreateInstance(theProp.PropertyType));
+                    theProp.SetValue(data, dto);
+                }
+                else // simple value type, assign it
+                {
+                    theProp.SetValue(data, kvp.Value);
+                }
             }
 
             return data;

--- a/src/Core/Requests/RequestDataConverter.cs
+++ b/src/Core/Requests/RequestDataConverter.cs
@@ -4,6 +4,7 @@ using System.Dynamic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using Skarp.HubSpotClient.Core.Interfaces;
 
 namespace Skarp.HubSpotClient.Core.Requests
@@ -43,11 +44,14 @@ namespace Skarp.HubSpotClient.Core.Requests
                 _logger.LogDebug("Mapping prop: '{0}' with serialization name: '{1}'", prop.Name, propSerializedName);
                 if (prop.Name.Equals("RouteBasePath") || prop.Name.Equals("IsNameValue")) { continue; }
 
+                // IF we have an complex type on the entity that we are trying to convert, let's NOT get the 
+                // string value of it, but simply pass the object along - it will be serialized later as JSON...
                 var propValue = prop.GetValue(entity);
+                var value = propValue.IsComplexType() ? propValue : propValue?.ToString();
                 var item = new HubspotDataEntityProp
                 {
                     Property = propSerializedName,
-                    Value = propValue?.ToString()
+                    Value = value
                 };
 
                 if (entity.IsNameValue)

--- a/src/Core/Requests/RequestDataConverter.cs
+++ b/src/Core/Requests/RequestDataConverter.cs
@@ -29,9 +29,8 @@ namespace Skarp.HubSpotClient.Core.Requests
             dynamic mapped = new ExpandoObject();
 
             mapped.Properties = new List<HubspotDataEntityProp>();
-
-            bool isv2Route = entity.IsNameValue;
-            _logger.LogDebug("isv2route: {0}", isv2Route);
+;
+            _logger.LogDebug("Use nameValue mapping?: {0}", entity.IsNameValue);
 
             var allProps = entity.GetType().GetProperties();
             _logger.LogDebug("Have {0} props to map", allProps.Length);
@@ -51,7 +50,7 @@ namespace Skarp.HubSpotClient.Core.Requests
                     Value = propValue?.ToString()
                 };
 
-                if (isv2Route)
+                if (entity.IsNameValue)
                 {
                     item.Property = null;
                     item.Name = propSerializedName;

--- a/src/Core/Requests/RequestSerializer.cs
+++ b/src/Core/Requests/RequestSerializer.cs
@@ -38,15 +38,22 @@ namespace Skarp.HubSpotClient.Core.Requests
         /// </summary>
         /// <param name="entity">The entity.</param>
         /// <returns>The serialized entity</returns>
-        public virtual string SerializeEntity(IHubSpotEntity entity)
+        public virtual string SerializeEntity(object obj)
         {
-            dynamic converted = _requestDataConverter.ToHubspotDataEntity(entity);
+            if (obj is IHubSpotEntity entity)
+            {
+                var converted = _requestDataConverter.ToHubspotDataEntity(entity);
 
-            entity.AcceptHubSpotDataEntity(ref converted);
+                entity.AcceptHubSpotDataEntity(ref converted);
+
+                return JsonConvert.SerializeObject(
+                    converted,
+                    _jsonSerializerSettings);
+            }
 
             return JsonConvert.SerializeObject(
-                   converted,
-                   _jsonSerializerSettings);
+                obj,
+                _jsonSerializerSettings);
         }
 
         /// <summary>

--- a/src/Deal/HubSpotDealClient.cs
+++ b/src/Deal/HubSpotDealClient.cs
@@ -111,7 +111,7 @@ namespace Skarp.HubSpotClient.Deal
         /// <param name="action"></param>
         /// <returns></returns>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public string PathResolver(IHubSpotEntity entity, HubSpotAction action)
+        public string PathResolver(IDealHubSpotEntity entity, HubSpotAction action)
         {
             switch (action)
             {

--- a/src/Deal/Interfaces/IDealHubSpotEntity.cs
+++ b/src/Deal/Interfaces/IDealHubSpotEntity.cs
@@ -12,5 +12,6 @@ namespace Skarp.HubSpotClient.Deal.Interfaces
         string CloseDate { get; set; }
         int Amount { get; set; }
         string DealType { get; set; }
+        string RouteBasePath { get; }
     }
 }

--- a/test/functional/Company/HubSpotCompanyClientFunctionalTest.cs
+++ b/test/functional/Company/HubSpotCompanyClientFunctionalTest.cs
@@ -22,7 +22,8 @@ namespace Skarp.HubSpotClient.FunctionalTests.Company
                 .AddTestCase(new GetCompanyMockTestCase())
                 .AddTestCase(new GetCompanyByIdNotFoundMockTestCase())
                 .AddTestCase(new UpdateCompanyMockTestCase())
-                .AddTestCase(new DeleteCompanyMockTestCase());
+                .AddTestCase(new DeleteCompanyMockTestCase())
+                .AddTestCase(new SearchByDomainMockTestCase());
 
             _client = new HubSpotCompanyClient(
                 mockHttpClient,
@@ -92,6 +93,17 @@ namespace Skarp.HubSpotClient.FunctionalTests.Company
         public async Task CompanyClient_delete_Company_works()
         {
             await _client.DeleteAsync(10444744);
+        }
+
+        [Fact]
+        public async Task CompanyClient_search_by_domain_works()
+        {
+            var request = new CompanySearchByDomain();
+
+            var response = await _client.GetByEmailAsync<CompanySearchResultEntity<CompanyHubSpotEntity>>("mr@miaki.io", request);
+
+            Assert.NotNull(response);
+            Assert.NotEmpty(response.Results);
         }
     }
 }

--- a/test/functional/Mocks/Company/SearchByDomainMockTestCase.cs
+++ b/test/functional/Mocks/Company/SearchByDomainMockTestCase.cs
@@ -1,0 +1,31 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using RapidCore.Network;
+using RapidCore.Threading;
+using Skarp.HubSpotClient.Core;
+
+namespace Skarp.HubSpotClient.FunctionalTests.Mocks.Company
+{
+    public class SearchByDomainMockTestCase : IMockRapidHttpClientTestCase
+    {
+        public bool IsMatch(HttpRequestMessage request)
+        {
+            var requestData = request.Content.ReadAsStringAsync().AwaitSync();
+            return request.RequestUri.AbsolutePath.EndsWith("/companies/v2/domains/miaki.io/companies");
+        }
+
+        public Task<HttpResponseMessage> GetResponseAsync(HttpRequestMessage request)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+
+            const string jsonResponse =
+                "{\"results\":[{\"portalId\":62515,\"companyId\":184896670,\"isDeleted\":false,\"properties\":{\"hs_lastmodifieddate\":{\"value\":\"1502872954691\",\"timestamp\":1502872954691,\"source\":\"CALCULATED\",\"sourceId\":null,\"versions\":[{\"name\":\"hs_lastmodifieddate\",\"value\":\"1502872954691\",\"timestamp\":1502872954691,\"source\":\"CALCULATED\",\"sourceVid\":[]}]},\"domain\":{\"value\":\"hubspot.com\",\"timestamp\":1457708103847,\"source\":\"COMPANIES\",\"sourceId\":null,\"versions\":[{\"name\":\"domain\",\"value\":\"hubspot.com\",\"timestamp\":1457708103847,\"source\":\"COMPANIES\",\"sourceVid\":[]}]},\"name\":{\"value\":\"Hubspot, Inc.\",\"timestamp\":1457708103906,\"source\":\"BIDEN\",\"sourceId\":\"name\",\"versions\":[{\"name\":\"name\",\"value\":\"Hubspot, Inc.\",\"timestamp\":1457708103906,\"sourceId\":\"name\",\"source\":\"BIDEN\",\"sourceVid\":[]}]},\"createdate\":{\"value\":\"1457708103847\",\"timestamp\":1457708103847,\"source\":\"API\",\"sourceId\":null,\"versions\":[{\"name\":\"createdate\",\"value\":\"1457708103847\",\"timestamp\":1457708103847,\"source\":\"API\",\"sourceVid\":[]}]}},\"additionalDomains\":[],\"stateChanges\":[],\"mergeAudits\":[]},{\"portalId\":62515,\"companyId\":418736767,\"isDeleted\":false,\"properties\":{\"hs_lastmodifieddate\":{\"value\":\"1498644245669\",\"timestamp\":1498644245669,\"source\":\"CALCULATED\",\"sourceId\":null,\"versions\":[{\"name\":\"hs_lastmodifieddate\",\"value\":\"1498644245669\",\"timestamp\":1498644245669,\"source\":\"CALCULATED\",\"sourceVid\":[]}]},\"domain\":{\"value\":\"hubspot.com\",\"timestamp\":1490280388204,\"source\":\"API\",\"sourceId\":null,\"versions\":[{\"name\":\"domain\",\"value\":\"hubspot.com\",\"timestamp\":1490280388204,\"source\":\"API\",\"sourceVid\":[]}]},\"name\":{\"value\":\"qweqwe2323\",\"timestamp\":1490280388204,\"source\":\"API\",\"sourceId\":null,\"versions\":[{\"name\":\"name\",\"value\":\"qweqwe2323\",\"timestamp\":1490280388204,\"source\":\"API\",\"sourceVid\":[]}]},\"createdate\":{\"value\":\"1490280388204\",\"timestamp\":1490280388204,\"source\":\"API\",\"sourceId\":\"API\",\"versions\":[{\"name\":\"createdate\",\"value\":\"1490280388204\",\"timestamp\":1490280388204,\"sourceId\":\"API\",\"source\":\"API\",\"sourceVid\":[]}]}},\"additionalDomains\":[],\"stateChanges\":[],\"mergeAudits\":[]}],\"hasMore\":true,\"offset\":{\"companyId\":418736767,\"isPrimary\":true}}";
+            response.Content = new JsonContent(jsonResponse);
+            response.RequestMessage = request;
+
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/test/unit/Core/ReflectionExtensionTest.cs
+++ b/test/unit/Core/ReflectionExtensionTest.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using System.Runtime.Serialization;
 using RapidCore.Reflection;
+using Skarp.HubSpotClient.Company;
 using Skarp.HubSpotClient.Contact.Dto;
 using Skarp.HubSpotClient.Core;
 using Xunit;
@@ -47,6 +48,21 @@ namespace Skarp.HubSpotClient.UnitTest.Core
 
             var propNoIgnore = dto.GetType().GetProperties().Single(p => p.Name == "MemberWithCustomName");
             Assert.False(propNoIgnore.HasIgnoreDataMemberAttribute());
+        }
+
+        [Fact]
+        public void ReflectionExtension_can_determine_if_stuff_is_complex()
+        {
+            string nuller = null;
+            var str = " Hey I am a string!";
+            var theAnswer = 42;
+
+            var complexBeast = new CompanySearchByDomain();
+
+            Assert.False(str.IsComplexType(), "str.IsComplexType()");
+            Assert.False(theAnswer.IsComplexType(), "theAnswer.IsComplexType()");
+            Assert.True(complexBeast.IsComplexType(), "complexBeast.IsComplexType()");
+            Assert.False(nuller.IsComplexType());
         }
 
         [DataContract]

--- a/test/unit/Core/Requests/RequestDataConverterTest.cs
+++ b/test/unit/Core/Requests/RequestDataConverterTest.cs
@@ -18,7 +18,6 @@ namespace Skarp.HubSpotClient.UnitTest.Core.Requests
         private readonly ContactHubSpotEntity _contactDto;
         private readonly CustomContactHubSpotEntity _customContactDto;
         private readonly CompanyHubSpotEntity _companyDto;
-        private readonly CompanySearchByDomain _companySearch;
 
         public RequestDataConverterTest(ITestOutputHelper output) : base(output)
         {
@@ -58,8 +57,6 @@ namespace Skarp.HubSpotClient.UnitTest.Core.Requests
                 Name = "Acme Inc",
                 Description = "The world famous Acme Inc"
             };
-
-            _companySearch = new CompanySearchByDomain();
         }
 
 
@@ -114,25 +111,6 @@ namespace Skarp.HubSpotClient.UnitTest.Core.Requests
                 Assert.NotNull(prop.Name);
                 Assert.NotNull(prop.Value);
             }
-        }
-
-        [Fact]
-        public void RequestDataConverter_converts_complex_props_on_entities()
-        {
-            var converted = _converter.ToHubspotDataEntity(_companySearch);
-            Assert.NotNull(converted);
-            var allProps = converted.Properties as List<HubspotDataEntityProp>;
-            Assert.NotNull(allProps);
-            Assert.NotEmpty(allProps);
-
-            Assert.Equal("100", allProps.Single(q => (string) q.Name =="limit").Value);
-            var requetOptions =
-                allProps.Single(q => (string) q.Name == "requestOptions").Value as CompanySearchRequestOptions;
-
-            Assert.NotNull(requetOptions);
-
-            var offset = allProps.Single(q => (string) q.Name == "offset").Value as CompanySearchOffset;
-            Assert.NotNull(offset);
         }
 
         [Fact]

--- a/test/unit/Core/Requests/RequestDataConverterTest.cs
+++ b/test/unit/Core/Requests/RequestDataConverterTest.cs
@@ -3,6 +3,7 @@ using System.Dynamic;
 using System.Linq;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
+using Skarp.HubSpotClient.Company;
 using Skarp.HubSpotClient.Company.Dto;
 using Skarp.HubSpotClient.Contact.Dto;
 using Skarp.HubSpotClient.Core.Requests;
@@ -16,7 +17,8 @@ namespace Skarp.HubSpotClient.UnitTest.Core.Requests
         private readonly RequestDataConverter _converter;
         private readonly ContactHubSpotEntity _contactDto;
         private readonly CustomContactHubSpotEntity _customContactDto;
-        private CompanyHubSpotEntity _companyDto;
+        private readonly CompanyHubSpotEntity _companyDto;
+        private readonly CompanySearchByDomain _companySearch;
 
         public RequestDataConverterTest(ITestOutputHelper output) : base(output)
         {
@@ -56,6 +58,8 @@ namespace Skarp.HubSpotClient.UnitTest.Core.Requests
                 Name = "Acme Inc",
                 Description = "The world famous Acme Inc"
             };
+
+            _companySearch = new CompanySearchByDomain();
         }
 
 
@@ -110,6 +114,25 @@ namespace Skarp.HubSpotClient.UnitTest.Core.Requests
                 Assert.NotNull(prop.Name);
                 Assert.NotNull(prop.Value);
             }
+        }
+
+        [Fact]
+        public void RequestDataConverter_converts_complex_props_on_entities()
+        {
+            var converted = _converter.ToHubspotDataEntity(_companySearch);
+            Assert.NotNull(converted);
+            var allProps = converted.Properties as List<HubspotDataEntityProp>;
+            Assert.NotNull(allProps);
+            Assert.NotEmpty(allProps);
+
+            Assert.Equal("100", allProps.Single(q => (string) q.Name =="limit").Value);
+            var requetOptions =
+                allProps.Single(q => (string) q.Name == "requestOptions").Value as CompanySearchRequestOptions;
+
+            Assert.NotNull(requetOptions);
+
+            var offset = allProps.Single(q => (string) q.Name == "offset").Value as CompanySearchOffset;
+            Assert.NotNull(offset);
         }
 
         [Fact]

--- a/test/unit/Core/Requests/RequestSerializerTest.cs
+++ b/test/unit/Core/Requests/RequestSerializerTest.cs
@@ -13,7 +13,7 @@ namespace Skarp.HubSpotClient.UnitTest.Core.Requests
         private readonly ITestOutputHelper _output;
         private readonly RequestSerializer _serializer;
         private readonly ContactHubSpotEntity _contactDto;
-        private CompanySearchByDomain _companySearch;
+        private readonly CompanySearchByDomain _companySearch;
 
         public RequestSerializerTest(ITestOutputHelper output) : base(output)
         {

--- a/test/unit/Core/Requests/RequestSerializerTest.cs
+++ b/test/unit/Core/Requests/RequestSerializerTest.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
+using Skarp.HubSpotClient.Company;
 using Skarp.HubSpotClient.Contact.Dto;
 using Skarp.HubSpotClient.Core.Requests;
 using Xunit;
@@ -11,6 +13,7 @@ namespace Skarp.HubSpotClient.UnitTest.Core.Requests
         private readonly ITestOutputHelper _output;
         private readonly RequestSerializer _serializer;
         private readonly ContactHubSpotEntity _contactDto;
+        private CompanySearchByDomain _companySearch;
 
         public RequestSerializerTest(ITestOutputHelper output) : base(output)
         {
@@ -30,6 +33,26 @@ namespace Skarp.HubSpotClient.UnitTest.Core.Requests
                 Website = "http://hubspot.com",
                 ZipCode = "02139"
             };
+
+            _companySearch = new CompanySearchByDomain
+            {
+                Limit = 2,
+                Offset = new CompanySearchOffset
+                {
+                    CompanyId = 0,
+                    IsPrimary = true
+                },
+                RequestOptions = new CompanySearchRequestOptions
+                {
+                    Properties = new List<string>
+                    {
+                        "domain",
+                        "createdate",
+                        "name",
+                        "hs_lastmodifieddate"
+                    }
+                }
+            };
         }
         
         [Fact]
@@ -37,6 +60,15 @@ namespace Skarp.HubSpotClient.UnitTest.Core.Requests
         {
             var json = _serializer.SerializeEntity(_contactDto);
             const string expectedJson = "{\"properties\":[{\"property\":\"email\",\"value\":\"testingapis@hubspot.com\"},{\"property\":\"firstname\",\"value\":\"Adrian\"},{\"property\":\"lastname\",\"value\":\"Mott\"},{\"property\":\"website\",\"value\":\"http://hubspot.com\"},{\"property\":\"company\",\"value\":\"HubSpot\"},{\"property\":\"phone\",\"value\":\"555-122-2323\"},{\"property\":\"address\",\"value\":\"25 First Street\"},{\"property\":\"city\",\"value\":\"Cambridge\"},{\"property\":\"state\",\"value\":\"MA\"},{\"property\":\"zipcode\",\"value\":\"02139\"}]}";
+            Assert.Equal(expectedJson, json);
+        }
+
+        [Fact]
+        public void RequestSerializer_serialzies_non_hubspot_entities()
+        {
+            var json = _serializer.SerializeEntity(_companySearch);
+            const string expectedJson =
+                "{\"limit\":2,\"requestOptions\":{\"properties\":[\"domain\",\"createdate\",\"name\",\"hs_lastmodifieddate\"]},\"offset\":{\"isPrimary\":true,\"companyId\":0}}";
             Assert.Equal(expectedJson, json);
         }
     }


### PR DESCRIPTION
# Summary
This PR is multi-faceted and fixes a number of issues

Test cases have been extended / added for all of the below mentioned items.

There is also a minor breaking change in pulling `RouteBasePath` out of `IHubSpotEntity` and into the "concrete interfaces" for each entity type - should be straight forward to fix by inheritors.

## Standard object json serialization

Some of the operations in the HubSpot API are simple poco => json mappings, like the company search by domain.
In these cases the DTO should not inherit from `IHubSpotEntity` but simply be a poco, and the request serializer will recognize this  and "just convert it"

## Complex type deserialization

Some of the HubSpot responses contains complex types, and the deserializer could not handle this.

## Complex type serialization

If a HubSpotEntity inheritor had complex types on it, they were serialized as their `ToString()` value, now they should be deeply serialized.

## Search company by email

Finally the Search for companies by email, using the search for company by domain underneath, should be working.