### PR TITLE
Fix malformed URL when listing contacts

### DIFF
--- a/src/Contact/HubSpotContactClient.cs
+++ b/src/Contact/HubSpotContactClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Flurl;
 using Microsoft.Extensions.Logging;
 using RapidCore.Network;
 using Skarp.HubSpotClient.Contact.Dto;
@@ -106,11 +107,11 @@ namespace Skarp.HubSpotClient.Contact
             {
                 opts = new ContactListRequestOptions();
             }
-            var path = PathResolver(new ContactHubSpotEntity(), HubSpotAction.List) +
-                       $"&count={opts.NumberOfContactsToReturn}";
+            var path = PathResolver(new ContactHubSpotEntity(), HubSpotAction.List)
+                .SetQueryParam("count", opts.NumberOfContactsToReturn);
             if (opts.ContactOffset.HasValue)
             {
-                path = path + $"?vidOffset={opts.ContactOffset}";
+                path = path.SetQueryParam("vidOffset", opts.ContactOffset);
             }
 
             var data = await ListAsync<T>(path);

--- a/src/Core/HubSpotBaseClient.cs
+++ b/src/Core/HubSpotBaseClient.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Flurl;
 using Microsoft.Extensions.Logging;
 using RapidCore.Network;
 using Skarp.HubSpotClient.Core.Interfaces;
@@ -166,7 +167,9 @@ namespace Skarp.HubSpotClient.Core
             Func<string, T> deserializeFunc)
             where T : IHubSpotEntity, new()
         {
-            var fullUrl = $"{HubSpotBaseUrl}{absoluteUriPath}?hapikey={_apiKey}";
+            var fullUrl = $"{HubSpotBaseUrl}{absoluteUriPath}"
+                .SetQueryParam("hapikey", _apiKey);
+            
             Logger.LogDebug("Full url: '{0}'", fullUrl);
 
             var request = new HttpRequestMessage

--- a/src/hubspot-client.csproj
+++ b/src/hubspot-client.csproj
@@ -17,6 +17,7 @@
     <Company>SKARP ApS</Company>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="flurl" Version="2.5.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/test/integration/Contact/HubSpotContactClientIntegrationTest.cs
+++ b/test/integration/Contact/HubSpotContactClientIntegrationTest.cs
@@ -57,5 +57,20 @@ namespace integration.Contact
             Assert.NotNull(retrieved);
             Assert.Equal("2300", retrieved.ZipCode);
         }
+
+        [Fact]
+        public async Task List_contacts_works()
+        {
+            var contacts =
+                await _client.ListAsync<ContactListHubSpotEntity<ContactHubSpotEntity>>(new ContactListRequestOptions
+                {
+                    NumberOfContactsToReturn = 5
+                });
+            
+            Assert.NotNull(contacts);
+            Assert.NotNull(contacts.Contacts);
+            Assert.NotEmpty(contacts.Contacts);
+            Assert.True(contacts.Contacts.Count == 5, "contacts.Contacts.Count == 5");
+        }
     }
 }


### PR DESCRIPTION
The URL was malformed and the underlying http request builder did
not take into account that the various clients could inject base urls
that already contained query params.

Pulled in flurl to allow dynamic building of query parameters on the
url that we are firing towards HubSpot.

Added integration test to show that list contact now works as intended

Closes #21 