### PR TITLE
Add interfaces for all clients

### DIFF
--- a/src/Associations/HubSpotAssociationsClient.cs
+++ b/src/Associations/HubSpotAssociationsClient.cs
@@ -4,17 +4,15 @@ using RapidCore.Network;
 using Skarp.HubSpotClient.Associations.Dto;
 using Skarp.HubSpotClient.Associations.Interfaces;
 using Skarp.HubSpotClient.Core;
-using Skarp.HubSpotClient.Core.Interfaces;
 using Skarp.HubSpotClient.Core.Requests;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Skarp.HubSpotClient.Associations
 {
-    public class HubSpotAssociationsClient : HubSpotBaseClient
+    public class HubSpotAssociationsClient : HubSpotBaseClient, IHubSpotAssociationsClient
     {
         /// <summary>
         /// Mockable and container ready constructor
@@ -25,11 +23,11 @@ namespace Skarp.HubSpotClient.Associations
         /// <param name="hubSpotBaseUrl"></param>
         /// <param name="apiKey"></param>
         public HubSpotAssociationsClient(
-            IRapidHttpClient httpClient, 
-            ILogger logger, 
-            RequestSerializer serializer, 
-            string hubSpotBaseUrl, 
-            string apiKey) 
+            IRapidHttpClient httpClient,
+            ILogger logger,
+            RequestSerializer serializer,
+            string hubSpotBaseUrl,
+            string apiKey)
              : base(httpClient, logger, serializer, hubSpotBaseUrl, apiKey)
         {
         }
@@ -133,7 +131,7 @@ namespace Skarp.HubSpotClient.Associations
         }
 
         /// <summary>
-        /// Resolve a hubspot API path based off the entity and opreation that is about to happen
+        /// Resolve a hubspot API path based off the entity and operation that is about to happen
         /// </summary>
         /// <param name="entity"></param>
         /// <param name="action"></param>

--- a/src/Associations/Interfaces/IHubSpotAssociationsClient.cs
+++ b/src/Associations/Interfaces/IHubSpotAssociationsClient.cs
@@ -1,0 +1,49 @@
+﻿using Skarp.HubSpotClient.Associations.Interfaces;
+using Skarp.HubSpotClient.Core;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Skarp.HubSpotClient.Associations
+{
+    public interface IHubSpotAssociationsClient
+    {
+        /// <summary>
+        /// Create association based on definition id
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        Task<bool> Create<T>(T entity, HubSpotAssociationDefinitions definitionId);
+        /// <summary>
+        /// Create in batch associations based on definition id
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        Task<bool> CreateBatch<T>(List<T> entities, HubSpotAssociationDefinitions definitionId);
+        /// <summary>
+        /// Delete association based on definition id
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        Task<bool> Delete<T>(T entity, HubSpotAssociationDefinitions definitionId);
+        /// <summary>
+        /// Delete in batch associations based on definition id
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        Task<bool> DeleteBatch<T>(List<T> entities, HubSpotAssociationDefinitions definitionId);
+        /// <summary>
+        /// Return a list of associations for a CRM object by id from hubspot based on the association definition id
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        Task<T> GetListByIdAsync<T>(long FromObjectId, HubSpotAssociationDefinitions definitionId, AssociationListRequestOptions opts = null);
+        /// <summary>
+        /// Resolve a hubspot API path based off the entity and operation that is about to happen
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <param name="action"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        string PathResolver(IAssociationHubSpotEntity entity, HubSpotAction action);
+    }
+}

--- a/src/Associations/Interfaces/IHubSpotAssociationsClient.cs
+++ b/src/Associations/Interfaces/IHubSpotAssociationsClient.cs
@@ -1,5 +1,4 @@
-﻿using Skarp.HubSpotClient.Associations.Interfaces;
-using Skarp.HubSpotClient.Core;
+﻿using Skarp.HubSpotClient.Core;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -37,13 +36,5 @@ namespace Skarp.HubSpotClient.Associations
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
         Task<T> GetListByIdAsync<T>(long FromObjectId, HubSpotAssociationDefinitions definitionId, AssociationListRequestOptions opts = null);
-        /// <summary>
-        /// Resolve a hubspot API path based off the entity and operation that is about to happen
-        /// </summary>
-        /// <param name="entity"></param>
-        /// <param name="action"></param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
-        string PathResolver(IAssociationHubSpotEntity entity, HubSpotAction action);
     }
 }

--- a/src/Company/HubSpotCompanyClient.cs
+++ b/src/Company/HubSpotCompanyClient.cs
@@ -13,7 +13,7 @@ using Skarp.HubSpotClient.Core.Requests;
 
 namespace Skarp.HubSpotClient.Company
 {
-    public class HubSpotCompanyClient : HubSpotBaseClient
+    public class HubSpotCompanyClient : HubSpotBaseClient, IHubSpotCompanyClient
     {
         /// <summary>
         /// Mockable and container ready constructor
@@ -44,10 +44,10 @@ namespace Skarp.HubSpotClient.Company
         /// <param name="apiKey">Your API key</param>
         public HubSpotCompanyClient(string apiKey)
         : base(
-              new RealRapidHttpClient(new HttpClient()), 
-              NoopLoggerFactory.Get(), 
+              new RealRapidHttpClient(new HttpClient()),
+              NoopLoggerFactory.Get(),
               new RequestSerializer(new RequestDataConverter(NoopLoggerFactory.Get<RequestDataConverter>())),
-              "https://api.hubapi.com", 
+              "https://api.hubapi.com",
               apiKey)
         { }
 
@@ -95,7 +95,7 @@ namespace Skarp.HubSpotClient.Company
             }
 
             var path = PathResolver(new CompanyHubSpotEntity(), HubSpotAction.GetByEmail)
-                .Replace(":domain:", email.Substring(email.IndexOf("@")+1));
+                .Replace(":domain:", email.Substring(email.IndexOf("@") + 1));
             var data = await ListAsPostAsync<T>(path, opts);
             return data;
         }
@@ -152,7 +152,7 @@ namespace Skarp.HubSpotClient.Company
         }
 
         /// <summary>
-        /// Resolve a hubspot API path based off the entity and opreation that is about to happen
+        /// Resolve a hubspot API path based off the entity and operation that is about to happen
         /// </summary>
         /// <param name="entity"></param>
         /// <param name="action"></param>

--- a/src/Company/Interfaces/IHubSpotCompanyClient.cs
+++ b/src/Company/Interfaces/IHubSpotCompanyClient.cs
@@ -1,0 +1,59 @@
+﻿using Skarp.HubSpotClient.Core;
+using Skarp.HubSpotClient.Core.Interfaces;
+using System.Threading.Tasks;
+
+namespace Skarp.HubSpotClient.Company.Interfaces
+{
+    public interface IHubSpotCompanyClient
+    {
+        /// <summary>
+        /// Creates the Company entity asynchronously.
+        /// </summary>
+        /// <param name="entity">The entity.</param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
+        Task<T> CreateAsync<T>(ICompanyHubSpotEntity entity) where T : IHubSpotEntity, new();
+        /// <summary>
+        /// Delete a company from hubspot by id
+        /// </summary>
+        /// <param name="CompanyId"></param>
+        /// <returns></returns>
+        Task DeleteAsync(long CompanyId);
+        /// <summary>
+        /// Get a Company by email address (only searches on domain)
+        /// </summary>
+        /// <param name="email"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        Task<T> GetByEmailAsync<T>(string email, CompanySearchByDomain opts = null) where T : IHubSpotEntity, new();
+        /// <summary>
+        /// Return a single Company by id from hubspot
+        /// </summary>
+        /// <param name="CompanyId"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        Task<T> GetByIdAsync<T>(long CompanyId) where T : IHubSpotEntity, new();
+        /// <summary>
+        /// List Companies 
+        /// </summary>
+        /// <param name="opts">Request options - use for pagination</param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        Task<T> ListAsync<T>(CompanyListRequestOptions opts = null) where T : IHubSpotEntity, new();
+        /// <summary>
+        /// Update an existing company in hubspot
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="entity"></param>
+        /// <returns></returns>
+        Task<T> UpdateAsync<T>(ICompanyHubSpotEntity entity) where T : IHubSpotEntity, new();
+        /// <summary>
+        /// Resolve a hubspot API path based off the entity and operation that is about to happen
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <param name="action"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        string PathResolver(ICompanyHubSpotEntity entity, HubSpotAction action);
+    }
+}

--- a/src/Company/Interfaces/IHubSpotCompanyClient.cs
+++ b/src/Company/Interfaces/IHubSpotCompanyClient.cs
@@ -1,5 +1,4 @@
-﻿using Skarp.HubSpotClient.Core;
-using Skarp.HubSpotClient.Core.Interfaces;
+﻿using Skarp.HubSpotClient.Core.Interfaces;
 using System.Threading.Tasks;
 
 namespace Skarp.HubSpotClient.Company.Interfaces
@@ -47,13 +46,5 @@ namespace Skarp.HubSpotClient.Company.Interfaces
         /// <param name="entity"></param>
         /// <returns></returns>
         Task<T> UpdateAsync<T>(ICompanyHubSpotEntity entity) where T : IHubSpotEntity, new();
-        /// <summary>
-        /// Resolve a hubspot API path based off the entity and operation that is about to happen
-        /// </summary>
-        /// <param name="entity"></param>
-        /// <param name="action"></param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
-        string PathResolver(ICompanyHubSpotEntity entity, HubSpotAction action);
     }
 }

--- a/src/Contact/HubSpotContactClient.cs
+++ b/src/Contact/HubSpotContactClient.cs
@@ -14,7 +14,7 @@ using Skarp.HubSpotClient.Core.Requests;
 
 namespace Skarp.HubSpotClient.Contact
 {
-    public class HubSpotContactClient : HubSpotBaseClient
+    public class HubSpotContactClient : HubSpotBaseClient, IHubSpotContactClient
     {
         /// <summary>
         /// Mockable and container ready constructor
@@ -45,10 +45,10 @@ namespace Skarp.HubSpotClient.Contact
         /// <param name="apiKey">Your API key</param>
         public HubSpotContactClient(string apiKey)
         : base(
-              new RealRapidHttpClient(new HttpClient()), 
-              NoopLoggerFactory.Get(), 
+              new RealRapidHttpClient(new HttpClient()),
+              NoopLoggerFactory.Get(),
               new RequestSerializer(new RequestDataConverter(NoopLoggerFactory.Get<RequestDataConverter>())),
-              "https://api.hubapi.com", 
+              "https://api.hubapi.com",
               apiKey)
         { }
 
@@ -167,7 +167,7 @@ namespace Skarp.HubSpotClient.Contact
         }
 
         /// <summary>
-        /// Resolve a hubspot API path based off the entity and opreation that is about to happen
+        /// Resolve a hubspot API path based off the entity and operation that is about to happen
         /// </summary>
         /// <param name="entity"></param>
         /// <param name="action"></param>

--- a/src/Contact/Interfaces/IHubSpotContactClient.cs
+++ b/src/Contact/Interfaces/IHubSpotContactClient.cs
@@ -1,5 +1,4 @@
-﻿using Skarp.HubSpotClient.Core;
-using Skarp.HubSpotClient.Core.Interfaces;
+﻿using Skarp.HubSpotClient.Core.Interfaces;
 using System.Threading.Tasks;
 
 namespace Skarp.HubSpotClient.Contact.Interfaces
@@ -47,14 +46,6 @@ namespace Skarp.HubSpotClient.Contact.Interfaces
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
         Task<T> ListAsync<T>(ContactListRequestOptions opts = null) where T : IHubSpotEntity, new();
-        /// <summary>
-        /// Resolve a hubspot API path based off the entity and operation that is about to happen
-        /// </summary>
-        /// <param name="entity"></param>
-        /// <param name="action"></param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
-        string PathResolver(IContactHubSpotEntity entity, HubSpotAction action);
         /// <summary>
         /// Update an existing contact in hubspot
         /// </summary>

--- a/src/Contact/Interfaces/IHubSpotContactClient.cs
+++ b/src/Contact/Interfaces/IHubSpotContactClient.cs
@@ -1,0 +1,65 @@
+﻿using Skarp.HubSpotClient.Core;
+using Skarp.HubSpotClient.Core.Interfaces;
+using System.Threading.Tasks;
+
+namespace Skarp.HubSpotClient.Contact.Interfaces
+{
+    public interface IHubSpotContactClient
+    {
+        /// <summary>
+        /// Creates the contact entity asynchronously.
+        /// </summary>
+        /// <param name="entity">The entity.</param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
+        Task<T> CreateAsync<T>(IContactHubSpotEntity entity) where T : IHubSpotEntity, new();
+        /// <summary>
+        /// Creates or updates the contact entity asynchronously.
+        /// </summary>
+        /// <param name="entity">The entity.</param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
+        Task<T> CreateOrUpdateAsync<T>(IContactHubSpotEntity entity) where T : IHubSpotEntity, new();
+        /// <summary>
+        /// Delete an existing contact in hubspot by id
+        /// </summary>
+        /// <param name="contactId"></param>
+        /// <returns></returns>
+        Task DeleteAsync(long contactId);
+        /// <summary>
+        /// Get a contact by email address
+        /// </summary>
+        /// <param name="email"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        Task<T> GetByEmailAsync<T>(string email) where T : IHubSpotEntity, new();
+        /// <summary>
+        /// Return a single contact by id from hubspot
+        /// </summary>
+        /// <param name="contactId"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        Task<T> GetByIdAsync<T>(long contactId) where T : IHubSpotEntity, new();
+        /// <summary>
+        /// List contacts 
+        /// </summary>
+        /// <param name="opts">Request options - use for pagination</param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        Task<T> ListAsync<T>(ContactListRequestOptions opts = null) where T : IHubSpotEntity, new();
+        /// <summary>
+        /// Resolve a hubspot API path based off the entity and operation that is about to happen
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <param name="action"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        string PathResolver(IContactHubSpotEntity entity, HubSpotAction action);
+        /// <summary>
+        /// Update an existing contact in hubspot
+        /// </summary>
+        /// <param name="contact"></param>
+        /// <returns></returns>
+        Task UpdateAsync(IContactHubSpotEntity contact);
+    }
+}

--- a/src/Deal/HubSpotDealClient.cs
+++ b/src/Deal/HubSpotDealClient.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 
 namespace Skarp.HubSpotClient.Deal
 {
-    public class HubSpotDealClient : HubSpotBaseClient
+    public class HubSpotDealClient : HubSpotBaseClient, IHubSpotDealClient
     {
         /// <summary>
         /// Mockable and container ready constructor
@@ -105,7 +105,7 @@ namespace Skarp.HubSpotClient.Deal
         }
 
         /// <summary>
-        /// Resolve a hubspot API path based off the entity and opreation that is about to happen
+        /// Resolve a hubspot API path based off the entity and operation that is about to happen
         /// </summary>
         /// <param name="entity"></param>
         /// <param name="action"></param>

--- a/src/Deal/Interfaces/IHubSpotDealClient.cs
+++ b/src/Deal/Interfaces/IHubSpotDealClient.cs
@@ -1,0 +1,45 @@
+﻿using Skarp.HubSpotClient.Core;
+using Skarp.HubSpotClient.Core.Interfaces;
+using System.Threading.Tasks;
+
+namespace Skarp.HubSpotClient.Deal.Interfaces
+{
+    public interface IHubSpotDealClient
+    {
+        /// <summary>
+        /// Creates the deal entity asynchronously.
+        /// </summary>
+        /// <param name="entity">The entity.</param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
+        Task<T> CreateAsync<T>(IDealHubSpotEntity entity) where T : IHubSpotEntity, new();
+        /// <summary>
+        /// Delete a deal from hubspot
+        /// </summary>
+        /// <param name="dealId"></param>
+        /// <returns></returns>
+        Task DeleteAsync(long dealId);
+        /// <summary>
+        /// Return a single deal by id from hubspot
+        /// </summary>
+        /// <param name="dealId"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        Task<T> GetByIdAsync<T>(long dealId) where T : IHubSpotEntity, new();
+        /// <summary>
+        /// Resolve a hubspot API path based off the entity and operation that is about to happen
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <param name="action"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        string PathResolver(IDealHubSpotEntity entity, HubSpotAction action);
+        /// <summary>
+        /// Update an existing deal in hubspot
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="entity"></param>
+        /// <returns></returns>
+        Task<T> UpdateAsync<T>(IDealHubSpotEntity entity) where T : IHubSpotEntity, new();
+    }
+}

--- a/src/Deal/Interfaces/IHubSpotDealClient.cs
+++ b/src/Deal/Interfaces/IHubSpotDealClient.cs
@@ -1,4 +1,4 @@
-﻿using Skarp.HubSpotClient.Core;
+using Skarp.HubSpotClient.Core;
 using Skarp.HubSpotClient.Core.Interfaces;
 using System.Threading.Tasks;
 
@@ -26,14 +26,6 @@ namespace Skarp.HubSpotClient.Deal.Interfaces
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
         Task<T> GetByIdAsync<T>(long dealId) where T : IHubSpotEntity, new();
-        /// <summary>
-        /// Resolve a hubspot API path based off the entity and operation that is about to happen
-        /// </summary>
-        /// <param name="entity"></param>
-        /// <param name="action"></param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
-        string PathResolver(IDealHubSpotEntity entity, HubSpotAction action);
         /// <summary>
         /// Update an existing deal in hubspot
         /// </summary>

--- a/src/ListOfContacts/HubSpotListOfContactsClient.cs
+++ b/src/ListOfContacts/HubSpotListOfContactsClient.cs
@@ -1,23 +1,18 @@
 using System;
-using System.Linq;
 using System.Net.Http;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Flurl;
 using Microsoft.Extensions.Logging;
 using RapidCore.Network;
-using Skarp.HubSpotClient.Company.Dto;
-using Skarp.HubSpotClient.Company.Interfaces;
 using Skarp.HubSpotClient.Contact.Dto;
 using Skarp.HubSpotClient.Core;
-using Skarp.HubSpotClient.Core.Interfaces;
 using Skarp.HubSpotClient.Core.Requests;
 using Skarp.HubSpotClient.ListOfContacts.Dto;
 using Skarp.HubSpotClient.ListOfContacts.Interfaces;
 
 namespace Skarp.HubSpotClient.ListOfContacts
 {
-    public class HubSpotListOfContactsClient : HubSpotBaseClient
+    public class HubSpotListOfContactsClient : HubSpotBaseClient, IHubSpotListOfContactsClient
     {
         /// <summary>
         /// Mockable and container ready constructor
@@ -109,7 +104,7 @@ namespace Skarp.HubSpotClient.ListOfContacts
         }
 
         /// <summary>
-        /// Resolve a hubspot API path based off the entity and opreation that is about to happen
+        /// Resolve a hubspot API path based off the entity and operation that is about to happen
         /// </summary>
         /// <param name="entity"></param>
         /// <param name="action"></param>

--- a/src/ListOfContacts/Interfaces/IHubSpotListOfContactsClient.cs
+++ b/src/ListOfContacts/Interfaces/IHubSpotListOfContactsClient.cs
@@ -1,6 +1,4 @@
-﻿using Skarp.HubSpotClient.Contact.Interfaces;
-using Skarp.HubSpotClient.Core;
-using Skarp.HubSpotClient.ListOfContacts.Dto;
+﻿using Skarp.HubSpotClient.ListOfContacts.Dto;
 using System.Threading.Tasks;
 
 namespace Skarp.HubSpotClient.ListOfContacts.Interfaces
@@ -25,13 +23,5 @@ namespace Skarp.HubSpotClient.ListOfContacts.Interfaces
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
         Task<bool> RemoveBatchAsync(HubSpotListOfContactsEntity contacts, long listId);
-        /// <summary>
-        /// Resolve a hubspot API path based off the entity and operation that is about to happen
-        /// </summary>
-        /// <param name="entity"></param>
-        /// <param name="action"></param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
-        string PathResolver(IContactHubSpotEntity entity, HubSpotAction action);
     }
 }

--- a/src/ListOfContacts/Interfaces/IHubSpotListOfContactsClient.cs
+++ b/src/ListOfContacts/Interfaces/IHubSpotListOfContactsClient.cs
@@ -1,0 +1,37 @@
+﻿using Skarp.HubSpotClient.Contact.Interfaces;
+using Skarp.HubSpotClient.Core;
+using Skarp.HubSpotClient.ListOfContacts.Dto;
+using System.Threading.Tasks;
+
+namespace Skarp.HubSpotClient.ListOfContacts.Interfaces
+{
+    public interface IHubSpotListOfContactsClient
+    {
+        /// <summary>
+        /// Return a list of contacts for a contact list by id from hubspot
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        Task<T> GetListByIdAsync<T>(long listId, ListOfContactsRequestOptions opts = null);
+        /// <summary>
+        /// Add list of contacts based on list id
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        Task<bool> AddBatchAsync(HubSpotListOfContactsEntity contacts, long listId);
+        /// <summary>
+        /// Remove list of contacts based on list id
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        Task<bool> RemoveBatchAsync(HubSpotListOfContactsEntity contacts, long listId);
+        /// <summary>
+        /// Resolve a hubspot API path based off the entity and operation that is about to happen
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <param name="action"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        string PathResolver(IContactHubSpotEntity entity, HubSpotAction action);
+    }
+}

--- a/src/Owner/HubSpotOwnerClient.cs
+++ b/src/Owner/HubSpotOwnerClient.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace Skarp.HubSpotClient.Owner
 {
-    public class HubSpotOwnerClient : HubSpotBaseClient
+    public class HubSpotOwnerClient : HubSpotBaseClient, IHubSpotOwnerClient
     {
         /// <summary>
         /// Mockable and container ready constructor
@@ -101,7 +101,7 @@ namespace Skarp.HubSpotClient.Owner
         }
 
         /// <summary>
-        /// Resolve a hubspot API path based off the entity and opreation that is about to happen
+        /// Resolve a hubspot API path based off the entity and operation that is about to happen
         /// </summary>
         /// <param name="entity"></param>
         /// <param name="action"></param>

--- a/src/Owner/Interfaces/IHubSpotOwnerClient.cs
+++ b/src/Owner/Interfaces/IHubSpotOwnerClient.cs
@@ -1,5 +1,4 @@
-﻿using Skarp.HubSpotClient.Core;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Skarp.HubSpotClient.Owner.Interfaces
@@ -27,13 +26,5 @@ namespace Skarp.HubSpotClient.Owner.Interfaces
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
         Task<IEnumerable<T>> ListAsync<T>(OwnerListRequestOptions opts = null) where T : IOwnerHubSpotEntity, new();
-        /// <summary>
-        /// Resolve a hubspot API path based off the entity and operation that is about to happen
-        /// </summary>
-        /// <param name="entity"></param>
-        /// <param name="action"></param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
-        string PathResolver(IOwnerHubSpotEntity entity, HubSpotAction action);
     }
 }

--- a/src/Owner/Interfaces/IHubSpotOwnerClient.cs
+++ b/src/Owner/Interfaces/IHubSpotOwnerClient.cs
@@ -1,0 +1,39 @@
+﻿using Skarp.HubSpotClient.Core;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Skarp.HubSpotClient.Owner.Interfaces
+{
+    public interface IHubSpotOwnerClient
+    {
+        /// <summary>
+        /// Return a single Owner by id from hubspot
+        /// </summary>
+        /// <param name="ownerId"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        Task<T> GetByIdAsync<T>(long ownerId) where T : IOwnerHubSpotEntity, new();
+        /// <summary>
+        /// Return a single Owner by id from hubspot
+        /// </summary>
+        /// <param name="ownerId"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        Task<T> GetByIdAsync<T>(string ownerId) where T : IOwnerHubSpotEntity, new();
+        /// <summary>
+        /// List Owners 
+        /// </summary>
+        /// <param name="opts">Request options - use for filtering</param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        Task<IEnumerable<T>> ListAsync<T>(OwnerListRequestOptions opts = null) where T : IOwnerHubSpotEntity, new();
+        /// <summary>
+        /// Resolve a hubspot API path based off the entity and operation that is about to happen
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <param name="action"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        string PathResolver(IOwnerHubSpotEntity entity, HubSpotAction action);
+    }
+}


### PR DESCRIPTION
Adds interfaces for all `*HubSpotClient` classes to make them easier to replace/inject.

Implementation of suggestion #43 

I did a `reorder and remove unused usings` in files I touched, which impacted formatting in a few files.