### PR TITLE
Associations API cleanup

### DIFF
--- a/src/Associations/Dto/AssociationHubSpotEntity.cs
+++ b/src/Associations/Dto/AssociationHubSpotEntity.cs
@@ -1,8 +1,6 @@
-﻿using Skarp.HubSpotClient.Associations.Interfaces;
-using System;
-using System.Collections.Generic;
+using Skarp.HubSpotClient.Associations.Interfaces;
+using Skarp.HubSpotClient.Core;
 using System.Runtime.Serialization;
-using System.Text;
 
 namespace Skarp.HubSpotClient.Associations.Dto
 {

--- a/src/Associations/HubSpotAssociationsClient.cs
+++ b/src/Associations/HubSpotAssociationsClient.cs
@@ -53,9 +53,11 @@ namespace Skarp.HubSpotClient.Associations
         /// <summary>
         /// Return a list of associations for a CRM object by id from hubspot based on the association definition id
         /// </summary>
-        /// <typeparam name="T"></typeparam>
+        /// <param name="fromObjectId">Object ID for which to list its associations</param>
+        /// <param name="definitionId">The definition ID of the associations to list</param>
+        /// <param name="opts">Additional request options, use for limiting and pagination</param>
         /// <returns></returns>
-        public async Task<T> GetListByIdAsync<T>(long FromObjectId, HubSpotAssociationDefinitions definitionId, AssociationListRequestOptions opts = null)
+        public async Task<IAssociationListHubSpotEntity<long>> GetListByIdAsync(long FromObjectId, HubSpotAssociationDefinitions definitionId, AssociationListRequestOptions opts = null)
         {
             Logger.LogDebug("Get associations for object with definition");
             if (opts == null)
@@ -70,7 +72,7 @@ namespace Skarp.HubSpotClient.Associations
             {
                 path = path.SetQueryParam("offset", opts.AssociationOffset);
             }
-            var data = await GetGenericAsync<T>(path);
+            var data = await GetGenericAsync<AssociationListHubSpotEntity<long>>(path);
             return data;
         }
 
@@ -79,9 +81,9 @@ namespace Skarp.HubSpotClient.Associations
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public async Task<bool> Create<T>(T entity, HubSpotAssociationDefinitions definitionId)
+        public async Task<bool> Create<T>(T entity)
         {
-            Logger.LogDebug("Create batch associations with definition");
+            Logger.LogDebug("Create association with definition");
 
             var path = PathResolver(new AssociationHubSpotEntity(), HubSpotAction.Create);
             var data = await PutOrPostGeneric(path, entity, false);
@@ -93,7 +95,7 @@ namespace Skarp.HubSpotClient.Associations
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public async Task<bool> CreateBatch<T>(List<T> entities, HubSpotAssociationDefinitions definitionId)
+        public async Task<bool> CreateBatch<T>(List<T> entities)
         {
             Logger.LogDebug("Create batch associations with definition");
 
@@ -107,7 +109,7 @@ namespace Skarp.HubSpotClient.Associations
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public async Task<bool> Delete<T>(T entity, HubSpotAssociationDefinitions definitionId)
+        public async Task<bool> Delete<T>(T entity)
         {
             Logger.LogDebug("Create batch associations with definition");
 
@@ -121,7 +123,7 @@ namespace Skarp.HubSpotClient.Associations
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public async Task<bool> DeleteBatch<T>(List<T> entities, HubSpotAssociationDefinitions definitionId)
+        public async Task<bool> DeleteBatch<T>(List<T> entities)
         {
             Logger.LogDebug("Delete batch associations with definition");
 

--- a/src/Associations/Interfaces/IAssociationHubSpotEntity.cs
+++ b/src/Associations/Interfaces/IAssociationHubSpotEntity.cs
@@ -1,7 +1,4 @@
-﻿using Skarp.HubSpotClient.Core.Interfaces;
-using System;
-using System.Collections.Generic;
-using System.Text;
+using Skarp.HubSpotClient.Core;
 
 namespace Skarp.HubSpotClient.Associations.Interfaces
 {

--- a/src/Associations/Interfaces/IAssociationListHubSpotEntity.cs
+++ b/src/Associations/Interfaces/IAssociationListHubSpotEntity.cs
@@ -1,7 +1,4 @@
-﻿using Skarp.HubSpotClient.Core.Interfaces;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace Skarp.HubSpotClient.Associations.Interfaces
 {
@@ -36,6 +33,5 @@ namespace Skarp.HubSpotClient.Associations.Interfaces
         /// The continuation offset.
         /// </value>
         long ContinuationOffset { get; set; }
-
     }
 }

--- a/src/Associations/Interfaces/IHubSpotAssociationsClient.cs
+++ b/src/Associations/Interfaces/IHubSpotAssociationsClient.cs
@@ -1,4 +1,5 @@
-﻿using Skarp.HubSpotClient.Core;
+﻿using Skarp.HubSpotClient.Associations.Interfaces;
+using Skarp.HubSpotClient.Core;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -11,30 +12,32 @@ namespace Skarp.HubSpotClient.Associations
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<bool> Create<T>(T entity, HubSpotAssociationDefinitions definitionId);
+        Task<bool> Create<T>(T entity);
         /// <summary>
         /// Create in batch associations based on definition id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<bool> CreateBatch<T>(List<T> entities, HubSpotAssociationDefinitions definitionId);
+        Task<bool> CreateBatch<T>(List<T> entities);
         /// <summary>
         /// Delete association based on definition id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<bool> Delete<T>(T entity, HubSpotAssociationDefinitions definitionId);
+        Task<bool> Delete<T>(T entity);
         /// <summary>
         /// Delete in batch associations based on definition id
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<bool> DeleteBatch<T>(List<T> entities, HubSpotAssociationDefinitions definitionId);
+        Task<bool> DeleteBatch<T>(List<T> entities);
         /// <summary>
         /// Return a list of associations for a CRM object by id from hubspot based on the association definition id
         /// </summary>
-        /// <typeparam name="T"></typeparam>
+        /// <param name="fromObjectId">Object ID for which to list its associations</param>
+        /// <param name="definitionId">The definition ID of the associations to list</param>
+        /// <param name="opts">Additional request options, use for limiting and pagination</param>
         /// <returns></returns>
-        Task<T> GetListByIdAsync<T>(long FromObjectId, HubSpotAssociationDefinitions definitionId, AssociationListRequestOptions opts = null);
+        Task<IAssociationListHubSpotEntity<long>> GetListByIdAsync(long fromObjectId, HubSpotAssociationDefinitions definitionId, AssociationListRequestOptions opts = null);
     }
 }

--- a/test/functional/Association/HubSpotAssociationClientFunctionalTest.cs
+++ b/test/functional/Association/HubSpotAssociationClientFunctionalTest.cs
@@ -2,9 +2,7 @@
 using Microsoft.Extensions.Logging;
 using Skarp.HubSpotClient.Associations;
 using Skarp.HubSpotClient.Core.Requests;
-using System;
 using System.Collections.Generic;
-using System.Text;
 using Xunit.Abstractions;
 using Xunit;
 using System.Threading.Tasks;
@@ -40,7 +38,7 @@ namespace Skarp.HubSpotClient.FunctionalTests.Association
         [Fact]
         public async Task CompanyClient_can_get_list_of_Associations()
         {
-            var data = await _client.GetListByIdAsync<AssociationListHubSpotEntity<long>>(
+            var data = await _client.GetListByIdAsync(
                 10444744,
                 Core.HubSpotAssociationDefinitions.CompanyToContact,
                 new AssociationListRequestOptions
@@ -62,7 +60,7 @@ namespace Skarp.HubSpotClient.FunctionalTests.Association
                 FromObjectId = 10444744,
                 ToObjectId = 259674,
                 DefinitionId = (int)HubSpotAssociationDefinitions.CompanyToContact
-            }, HubSpotAssociationDefinitions.CompanyToContact);
+            });
 
             Assert.True(result);
         }
@@ -85,7 +83,7 @@ namespace Skarp.HubSpotClient.FunctionalTests.Association
                 DefinitionId = (int)HubSpotAssociationDefinitions.CompanyToContact
             }
             };
-            var result = await _client.CreateBatch(entities, HubSpotAssociationDefinitions.CompanyToContact);
+            var result = await _client.CreateBatch(entities);
 
             Assert.True(result);
         }
@@ -121,7 +119,7 @@ namespace Skarp.HubSpotClient.FunctionalTests.Association
                 DefinitionId = (int)HubSpotAssociationDefinitions.CompanyToContact
             }
              };
-                 _ = await localClient.CreateBatch(entities, HubSpotAssociationDefinitions.CompanyToContact);
+                 _ = await localClient.CreateBatch(entities);
              });
 
         }
@@ -134,7 +132,7 @@ namespace Skarp.HubSpotClient.FunctionalTests.Association
                 FromObjectId = 10444744,
                 ToObjectId = 259674,
                 DefinitionId = (int)HubSpotAssociationDefinitions.CompanyToContact
-            }, HubSpotAssociationDefinitions.CompanyToContact);
+            });
 
             Assert.True(result);
         }
@@ -157,7 +155,7 @@ namespace Skarp.HubSpotClient.FunctionalTests.Association
                 DefinitionId = (int)HubSpotAssociationDefinitions.CompanyToContact
             }
             };
-            var result = await _client.DeleteBatch(entities, HubSpotAssociationDefinitions.CompanyToContact);
+            var result = await _client.DeleteBatch(entities);
 
             Assert.True(result);
         }

--- a/test/unit/Association/HubSpotAssociationClientTest.cs
+++ b/test/unit/Association/HubSpotAssociationClientTest.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using FakeItEasy;
 using RapidCore.Network;
 using Skarp.HubSpotClient.Core;
-using Skarp.HubSpotClient.Core.Interfaces;
 using Skarp.HubSpotClient.Core.Requests;
 using Xunit;
 using Xunit.Abstractions;
@@ -78,7 +77,7 @@ namespace Skarp.HubSpotClient.UnitTest.Association
                 FromObjectId = 10444744,
                 ToObjectId = 259674,
                 DefinitionId = (int)HubSpotAssociationDefinitions.CompanyToContact
-            }, HubSpotAssociationDefinitions.CompanyToContact);
+            });
 
             A.CallTo(() => _mockHttpClient.SendAsync(A<HttpRequestMessage>.Ignored)).MustHaveHappened();
             A.CallTo(() => _mockSerializer.SerializeEntity(A<AssociationHubSpotEntity>.Ignored)).MustHaveHappened();
@@ -102,7 +101,7 @@ namespace Skarp.HubSpotClient.UnitTest.Association
                 DefinitionId = (int)HubSpotAssociationDefinitions.CompanyToContact
             }
             };
-            var result = await _client.CreateBatch(entities, HubSpotAssociationDefinitions.CompanyToContact);
+            var result = await _client.CreateBatch(entities);
 
             A.CallTo(() => _mockHttpClient.SendAsync(A<HttpRequestMessage>.Ignored)).MustHaveHappened();
             A.CallTo(() => _mockSerializer.SerializeEntities(A<List<AssociationHubSpotEntity>>.Ignored)).MustHaveHappened();
@@ -116,7 +115,7 @@ namespace Skarp.HubSpotClient.UnitTest.Association
                 FromObjectId = 10444744,
                 ToObjectId = 259674,
                 DefinitionId = (int)HubSpotAssociationDefinitions.CompanyToContact
-            }, HubSpotAssociationDefinitions.CompanyToContact);
+            });
 
             A.CallTo(() => _mockHttpClient.SendAsync(A<HttpRequestMessage>.Ignored)).MustHaveHappened();
             A.CallTo(() => _mockSerializer.SerializeEntity(A<AssociationHubSpotEntity>.Ignored)).MustHaveHappened();
@@ -140,7 +139,7 @@ namespace Skarp.HubSpotClient.UnitTest.Association
                 DefinitionId = (int)HubSpotAssociationDefinitions.CompanyToContact
             }
             };
-            var result = await _client.DeleteBatch(entities, HubSpotAssociationDefinitions.CompanyToContact);
+            var result = await _client.DeleteBatch(entities);
 
             A.CallTo(() => _mockHttpClient.SendAsync(A<HttpRequestMessage>.Ignored)).MustHaveHappened();
             A.CallTo(() => _mockSerializer.SerializeEntities(A<List<AssociationHubSpotEntity>>.Ignored)).MustHaveHappened();
@@ -149,7 +148,7 @@ namespace Skarp.HubSpotClient.UnitTest.Association
         [Fact]
         public async Task AssociationClient_list_companies_work()
         {
-            var response = await _client.GetListByIdAsync<AssociationListHubSpotEntity<long>>(
+            var response = await _client.GetListByIdAsync(
                 10444744,
                 HubSpotAssociationDefinitions.CompanyToContact,
                 new AssociationListRequestOptions


### PR DESCRIPTION
While working with the `Associations` API I made some wrong assumptions based on the interface definition:

- I assumed that the `definitionId` parameter of all methods (create, update, etc) would be applied to the entities I was sending. This was not the case, these parameters were never used; Since the `IAssociationHubSpotEntity` already have a `DefinitionId` property, I think these parameters are redundant and confusing.
- The `List` method on the API only returns a fixed list entity with a list of `long` Id's, so there is not much use for having a generic type parameter here. I removed it and made it explicit that the method returns an `IAssociationListHubSpotEntity<long>`.

This PR breaks the public interface!  