### PR TITLE
Add request options to Contact get operations

### DIFF
--- a/src/Contact/ContactRequestOptions.cs
+++ b/src/Contact/ContactRequestOptions.cs
@@ -1,9 +1,24 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Skarp.HubSpotClient.Contact
 {
+    public enum ContactFormSubmissionMode
+    {
+        All,
+        None,
+        Newest,
+        Oldest
+    }
+
+    public class ContactGetRequestOptions
+    {
+        public List<string> PropertiesToInclude { get; set; } = new List<string>();
+        public bool IncludeHistory { get; set; } = true; // this is the default in HubSpot
+        public ContactFormSubmissionMode FormSubmissionMode { get; set; } = ContactFormSubmissionMode.All; // this is the default in HubSpot
+        public bool IncludeListMemberships { get; set; } = true; // this is the default in HubSpot
+    }
+
     public class ContactListRequestOptions
     {
         private int _numberOfContactsToReturn = 20;

--- a/src/Contact/HubSpotContactClient.cs
+++ b/src/Contact/HubSpotContactClient.cs
@@ -85,13 +85,17 @@ namespace Skarp.HubSpotClient.Contact
         /// Return a single contact by id from hubspot
         /// </summary>
         /// <param name="contactId"></param>
+        /// <param name="opts">Options for enabling/disabling history and specifying properties</param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public async Task<T> GetByIdAsync<T>(long contactId) where T : IHubSpotEntity, new()
+        public async Task<T> GetByIdAsync<T>(long contactId, ContactGetRequestOptions opts = null) where T : IHubSpotEntity, new()
         {
             Logger.LogDebug("Contact Get by id ");
             var path = PathResolver(new ContactHubSpotEntity(), HubSpotAction.Get)
                 .Replace(":contactId:", contactId.ToString());
+
+            path = AddGetRequestOptions(path, opts);
+
             var data = await GetAsync<T>(path);
             return data;
         }
@@ -100,15 +104,38 @@ namespace Skarp.HubSpotClient.Contact
         /// Get a contact by email address
         /// </summary>
         /// <param name="email"></param>
+        /// <param name="opts">Options for enabling/disabling history and specifying properties</param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public async Task<T> GetByEmailAsync<T>(string email) where T : IHubSpotEntity, new()
+        public async Task<T> GetByEmailAsync<T>(string email, ContactGetRequestOptions opts = null) where T : IHubSpotEntity, new()
         {
             Logger.LogDebug("Contact get by email");
             var path = PathResolver(new ContactHubSpotEntity(), HubSpotAction.GetByEmail)
                 .Replace(":contactEmail:", email);
+
+            path = AddGetRequestOptions(path, opts);
+
             var data = await GetAsync<T>(path);
             return data;
+        }
+
+        private string AddGetRequestOptions(string path, ContactGetRequestOptions opts = null)
+        {
+            var newPath = path;
+
+            opts ??= new ContactGetRequestOptions();
+            if (opts.PropertiesToInclude.Any())
+            {
+                newPath = newPath.SetQueryParam("property", opts.PropertiesToInclude);
+            }
+            if (!opts.IncludeHistory)
+            {
+                newPath = newPath.SetQueryParam("propertyMode", "value_only");
+            }
+            newPath = newPath.SetQueryParam("formSubmissionMode", opts.FormSubmissionMode.ToString().ToLowerInvariant());
+            newPath = newPath.SetQueryParam("showListMemberships", opts.IncludeListMemberships.ToString().ToLowerInvariant());
+
+            return newPath;
         }
 
         /// <summary>

--- a/src/Contact/Interfaces/IHubSpotContactClient.cs
+++ b/src/Contact/Interfaces/IHubSpotContactClient.cs
@@ -1,4 +1,4 @@
-﻿using Skarp.HubSpotClient.Core.Interfaces;
+using Skarp.HubSpotClient.Core.Interfaces;
 using System.Threading.Tasks;
 
 namespace Skarp.HubSpotClient.Contact.Interfaces
@@ -29,16 +29,18 @@ namespace Skarp.HubSpotClient.Contact.Interfaces
         /// Get a contact by email address
         /// </summary>
         /// <param name="email"></param>
+        /// <param name="opts">Options for enabling/disabling history and specifying properties</param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<T> GetByEmailAsync<T>(string email) where T : IHubSpotEntity, new();
+        Task<T> GetByEmailAsync<T>(string email, ContactGetRequestOptions opts = null) where T : IHubSpotEntity, new();
         /// <summary>
         /// Return a single contact by id from hubspot
         /// </summary>
         /// <param name="contactId"></param>
+        /// <param name="opts">Options for enabling/disabling history and specifying properties</param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        Task<T> GetByIdAsync<T>(long contactId) where T : IHubSpotEntity, new();
+        Task<T> GetByIdAsync<T>(long contactId, ContactGetRequestOptions opts = null) where T : IHubSpotEntity, new();
         /// <summary>
         /// List contacts 
         /// </summary>

--- a/test/functional/Contact/HubSpotContactClientFunctionalTest.cs
+++ b/test/functional/Contact/HubSpotContactClientFunctionalTest.cs
@@ -1,16 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using RapidCore.Network;
 using Skarp.HubSpotClient.Contact;
 using Skarp.HubSpotClient.Contact.Dto;
 using Skarp.HubSpotClient.Core.Requests;
-using Skarp.HubSpotClient.FunctionalTests.Mocks;
 using Xunit;
 using Xunit.Abstractions;
 using Skarp.HubSpotClient.FunctionalTests.Mocks.Contact;
+using System.Collections.Generic;
 
 namespace Skarp.HubSpotClient.FunctionalTests.Contact
 {
@@ -99,7 +96,14 @@ namespace Skarp.HubSpotClient.FunctionalTests.Contact
         public async Task ContactClient_can_get_contact()
         {
             const int contactId = 3234574;
-            var data = await _client.GetByIdAsync<ContactHubSpotEntity>(contactId);
+            var options = new ContactGetRequestOptions
+            {
+                PropertiesToInclude = new List<string> { "my_custom_property" },
+                FormSubmissionMode = ContactFormSubmissionMode.Newest,
+                IncludeHistory = false,
+                IncludeListMemberships = false
+            };
+            var data = await _client.GetByIdAsync<ContactHubSpotEntity>(contactId, options);
 
             Assert.NotNull(data);
             Assert.Equal("Codey", data.FirstName);
@@ -111,7 +115,14 @@ namespace Skarp.HubSpotClient.FunctionalTests.Contact
         public async Task ContactClient_can_get_contact_by_email()
         {
             const string email = "testingapis@hubspot.com";
-            var data = await _client.GetByEmailAsync<ContactHubSpotEntity>(email);
+            var options = new ContactGetRequestOptions
+            {
+                PropertiesToInclude = new List<string> { "my_custom_property", "hs_object_id" },
+                FormSubmissionMode = ContactFormSubmissionMode.Newest,
+                IncludeHistory = false,
+                IncludeListMemberships = false
+            };
+            var data = await _client.GetByEmailAsync<ContactHubSpotEntity>(email, options);
 
             Assert.NotNull(data);
             Assert.Equal("Codey", data.FirstName);

--- a/test/functional/Mocks/Contact/GetContactByEmailMockTestCase.cs
+++ b/test/functional/Mocks/Contact/GetContactByEmailMockTestCase.cs
@@ -10,7 +10,13 @@ namespace Skarp.HubSpotClient.FunctionalTests.Mocks.Contact
     {
         public bool IsMatch(HttpRequestMessage request)
         {
-            return request.RequestUri.AbsolutePath.Contains("/contacts/v1/contact/email/testingapis@hubspot.com") && request.Method == HttpMethod.Get;
+            return request.RequestUri.AbsolutePath.Contains("/contacts/v1/contact/email/testingapis@hubspot.com") 
+                && request.RequestUri.Query.Contains("property=my_custom_property")
+                && request.RequestUri.Query.Contains("property=hs_object_id")
+                && request.RequestUri.Query.Contains("propertyMode=value_only")
+                && request.RequestUri.Query.Contains("formSubmissionMode=newest")
+                && request.RequestUri.Query.Contains("showListMemberships=false")
+                && request.Method == HttpMethod.Get;
         }
 
         public Task<HttpResponseMessage> GetResponseAsync(HttpRequestMessage request)

--- a/test/functional/Mocks/Contact/GetContactMockTestCase.cs
+++ b/test/functional/Mocks/Contact/GetContactMockTestCase.cs
@@ -10,7 +10,12 @@ namespace Skarp.HubSpotClient.FunctionalTests.Mocks.Contact
     {
         public bool IsMatch(HttpRequestMessage request)
         {
-            return request.RequestUri.AbsolutePath.Contains("/contacts/v1/contact/vid") && request.Method == HttpMethod.Get;
+            return request.RequestUri.AbsolutePath.Contains("/contacts/v1/contact/vid")
+                && request.RequestUri.Query.Contains("property=my_custom_property")
+                && request.RequestUri.Query.Contains("propertyMode=value_only")
+                && request.RequestUri.Query.Contains("formSubmissionMode=newest")
+                && request.RequestUri.Query.Contains("showListMemberships=false")
+                && request.Method == HttpMethod.Get;
         }
 
         public Task<HttpResponseMessage> GetResponseAsync(HttpRequestMessage request)


### PR DESCRIPTION
This adds request options to the `Contact` API for `GetById` and `GetByEmail`:

- `IncludedProperties`
- `IncludeHistory`
- `FormSubmissionMode`
- `IncludeListMemberships`

Note: this PR requires #49 to be merged first since it uses C# 9 language features.