### PR TITLE
Update Nugets

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ If you find something missing or broken, please [report an issue][github-issue] 
 
 Packages for the following dotnet versions are available:
 
-- dotnet 4.6
-- netstandard 1.6
+- dotnet 4.6.1
+- netstandard 2.0
 
-Which means that you can use the library with `fat-framework >= 4.6` or `netcoreapp >= 1.0`
+Which means that you can use the library with `fat-framework >= 4.6.1` or `netcoreapp >= 2.0`
 
 Verified working on Linux, macOS and Windows.
 

--- a/src/hubspot-client.csproj
+++ b/src/hubspot-client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <Version>0.13.0</Version>
     <AssemblyName>Skarp.HubSpotClient</AssemblyName>
     <RootNamespace>Skarp.HubSpotClient</RootNamespace>
@@ -17,10 +17,10 @@
     <Company>SKARP ApS</Company>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="flurl" Version="2.8.2" />
+    <PackageReference Include="flurl" Version="3.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="RapidCore" Version="0.21.0" />
+    <PackageReference Include="RapidCore" Version="0.23.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
   </ItemGroup>
 

--- a/test/functional/functional.csproj
+++ b/test/functional/functional.csproj
@@ -6,11 +6,11 @@
     <RootNamespace>Skarp.HubSpotClient.FunctionalTests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="RapidCore.Xunit" Version="0.22.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="RapidCore.Xunit" Version="0.23.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/integration/integration.csproj
+++ b/test/integration/integration.csproj
@@ -4,11 +4,11 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="RapidCore.Xunit" Version="0.22.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="RapidCore.Xunit" Version="0.23.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/unit/unit.csproj
+++ b/test/unit/unit.csproj
@@ -6,12 +6,12 @@
     <RootNamespace>Skarp.HubSpotClient.UnitTest</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="6.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="RapidCore.Xunit" Version="0.22.0" />
+    <PackageReference Include="FakeItEasy" Version="6.2.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="RapidCore.Xunit" Version="0.23.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Updates NuGet references to the latest to stay up to date.

This is a breaking change since it updates target frameworks.