### PR TITLE
Add Batch Read for Line Items

### DIFF
--- a/src/Core/HubSpotAction.cs
+++ b/src/Core/HubSpotAction.cs
@@ -23,6 +23,8 @@
 
         DeleteBatch,
 
-        UpdateBatch
+        UpdateBatch,
+
+        ReadBatch
     }
 }

--- a/src/Core/Requests/RequestSerializer.cs
+++ b/src/Core/Requests/RequestSerializer.cs
@@ -178,6 +178,24 @@ namespace Skarp.HubSpotClient.Core.Requests
         }
 
         /// <summary>
+        /// Deserialize the given JSON into a dictionary.
+        /// </summary>
+        /// <param name="json">The JSON data returned from a batch read request to HubSpot</param>
+        /// <returns></returns>
+        public virtual IDictionary<TKey, TEntity> DeserializeDictionaryOfEntities<TKey, TEntity>(string json) where TEntity : IHubSpotEntity, new()
+        {
+            var untypedDictionary = JsonConvert.DeserializeObject<IDictionary<TKey, ExpandoObject>>(json);
+
+            var convertedDictionary = new Dictionary<TKey, TEntity>();
+            foreach (var pair in untypedDictionary)
+            {
+                convertedDictionary.Add(pair.Key, _requestDataConverter.FromHubSpotResponse<TEntity>(pair.Value));
+            }
+
+            return convertedDictionary;
+        }
+
+        /// <summary>
         /// Deserialize the given JSON into a list of <see cref="IHubSpotEntity"/>
         /// </summary>
         /// <param name="json">The JSON data returned from a HubSpot operation</param>

--- a/src/LineItem/Interfaces/IHubSpotLineItemClient.cs
+++ b/src/LineItem/Interfaces/IHubSpotLineItemClient.cs
@@ -47,6 +47,13 @@ namespace Skarp.HubSpotClient.LineItem.Interfaces
         /// <returns></returns>
         Task<T> ListAsync<T>(LineItemListRequestOptions opts = null) where T : IHubSpotEntity, new();
         /// <summary>
+        /// Read a batch of line items from hubspot
+        /// </summary>
+        /// <param name="lineItemIds"></param>
+        /// <param name="opts"></param>
+        /// <returns></returns>
+        Task<IDictionary<long, T>> ReadBatchAsync<T>(ListOfLineItemIds lineItemIds, LineItemGetRequestOptions opts = null) where T : IHubSpotEntity, new();
+        /// <summary>
         /// Update an existing line item in hubspot
         /// </summary>
         /// <typeparam name="T"></typeparam>

--- a/src/LineItem/Interfaces/LineItemRequestOptions.cs
+++ b/src/LineItem/Interfaces/LineItemRequestOptions.cs
@@ -5,6 +5,7 @@ namespace Skarp.HubSpotClient.LineItem
     public class LineItemGetRequestOptions
     {
         public List<string> PropertiesToInclude { get; set; } = new List<string>();
+        public List<string> PropertiesWithHistoryToInclude { get; set; } = new List<string>();
         public bool IncludeDeletes { get; set; }
     }
 }

--- a/test/functional/LineItem/HubSpotLineItemClientFunctionalTest.cs
+++ b/test/functional/LineItem/HubSpotLineItemClientFunctionalTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using RapidCore.Network;
 using Skarp.HubSpotClient.Core.Requests;
@@ -28,7 +28,8 @@ namespace Skarp.HubSpotClient.FunctionalTests.LineItem
                 .AddTestCase(new UpdateLineItemMockTestCase())
                 .AddTestCase(new UpdateBatchLineItemMockTestCase())
                 .AddTestCase(new DeleteLineItemMockTestCase())
-                .AddTestCase(new DeleteBatchLineItemMockTestCase());
+                .AddTestCase(new DeleteBatchLineItemMockTestCase())
+                .AddTestCase(new ReadBatchLineItemMockTestCase());
 
             _client = new HubSpotLineItemClient(
                 mockHttpClient,
@@ -174,6 +175,20 @@ namespace Skarp.HubSpotClient.FunctionalTests.LineItem
             request.Ids.Add(9867221);
 
             await _client.DeleteBatchAsync(request);
+        }
+
+        [Fact]
+        public async Task LineItemClient_batch_read_LineItem_works()
+        {
+            var request = new ListOfLineItemIds();
+
+            request.Ids.Add(9867220);
+            request.Ids.Add(9867221);
+
+            var response = await _client.ReadBatchAsync<LineItemHubSpotEntity>(request);
+
+            Assert.Equal(2, response.Count());
+            Assert.Equal("1645342", response[9845651].ProductId);
         }
 
         [Fact]

--- a/test/functional/Mocks/LineItem/ReadBatchLineItemMockTestCase.cs
+++ b/test/functional/Mocks/LineItem/ReadBatchLineItemMockTestCase.cs
@@ -1,0 +1,27 @@
+﻿using RapidCore.Network;
+using Skarp.HubSpotClient.Core;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Skarp.HubSpotClient.FunctionalTests.Mocks.LineItem
+{
+    internal class ReadBatchLineItemMockTestCase : IMockRapidHttpClientTestCase
+    {
+        public bool IsMatch(HttpRequestMessage request)
+        {
+            return request.RequestUri.AbsolutePath.EndsWith("/crm-objects/v1/objects/line_items/batch-read") && request.Method == HttpMethod.Post;
+        }
+
+        public Task<HttpResponseMessage> GetResponseAsync(HttpRequestMessage request)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+
+            const string jsonResponse = "{'9845651':{'objectType':'LINE_ITEM','portalId':62515,'objectId':9845651,'properties':{'hs_product_id':{'versions':[{'name':'hs_product_id','value':'1645342','sourceVid':[]}],'value':'1645342','timestamp':0,'source':null,'sourceId':null}},'version':1,'isDeleted':false},'9867373':{'objectType':'LINE_ITEM','portalId':62515,'objectId':9867373,'properties':{'hs_product_id':{'versions':[{'name':'hs_product_id','value':'1645187','sourceVid':[]}],'value':'1645187','timestamp':0,'source':null,'sourceId':null}},'version':1,'isDeleted':false}}";
+            response.Content = new JsonContent(jsonResponse);
+            response.RequestMessage = request;
+
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/test/unit/Core/Requests/RequestSerializerTest.cs
+++ b/test/unit/Core/Requests/RequestSerializerTest.cs
@@ -94,6 +94,16 @@ namespace Skarp.HubSpotClient.UnitTest.Core.Requests
         }
 
         [Fact]
+        public void RequestSerializer_deserializes_dictionary_of_entities()
+        {
+            var json = "{'9845651':{'objectType':'LINE_ITEM','portalId':62515,'objectId':9845651,'properties':{'hs_product_id':{'versions':[{'name':'hs_product_id','value':'1645342','sourceVid':[]}],'value':'1645342','timestamp':0,'source':null,'sourceId':null}},'version':1,'isDeleted':false},'9867373':{'objectType':'LINE_ITEM','portalId':62515,'objectId':9867373,'properties':{'hs_product_id':{'versions':[{'name':'hs_product_id','value':'1645187','sourceVid':[]}],'value':'1645187','timestamp':0,'source':null,'sourceId':null}},'version':1,'isDeleted':false}}";
+            var result = _serializer.DeserializeDictionaryOfEntities<long, LineItemHubSpotEntity>(json);
+
+            Assert.Equal(2, result.Count());
+            Assert.Equal("1645342", result[9845651].ProductId);
+        }
+
+        [Fact]
         public void RequestSerializer_serializes_entity_to_namevaluelist()
         {
             var json = _serializer.SerializeEntityToNameValueList(_contactDto);

--- a/test/unit/LineItem/HubSpotLineItemClientTest.cs
+++ b/test/unit/LineItem/HubSpotLineItemClientTest.cs
@@ -1,4 +1,4 @@
-﻿using FakeItEasy;
+using FakeItEasy;
 using RapidCore.Network;
 using Skarp.HubSpotClient.Core;
 using Skarp.HubSpotClient.Core.Requests;
@@ -63,6 +63,7 @@ namespace Skarp.HubSpotClient.UnitTest.LineItem
         [InlineData(HubSpotAction.UpdateBatch, "/crm-objects/v1/objects/line_items/batch-update")]
         [InlineData(HubSpotAction.Delete, "/crm-objects/v1/objects/line_items/:lineItemId:")]
         [InlineData(HubSpotAction.DeleteBatch, "/crm-objects/v1/objects/line_items/batch-delete")]
+        [InlineData(HubSpotAction.ReadBatch, "/crm-objects/v1/objects/line_items/batch-read")]
         public void LineItemClient_path_resolver_works(HubSpotAction action, string expectedPath)
         {
             var resvoledPath = _client.PathResolver(new LineItemHubSpotEntity(), action);


### PR DESCRIPTION
Implements #54: `batch-read` API for `Line Items`.

This method returns a somewhat unconventional response compared to other API's: it is a dictionary of `LineItemHubSpotEntity` where each key is a line item ID, and each value is a `LineItemHubSpotEntity`. I added `DeserializeDictionaryOfEntities<TKey, TEntity>()` to the `RequestSerializer` to facilitate this.