### PR TITLE
Added get list of contact lists

### DIFF
--- a/src/Core/HubSpotAction.cs
+++ b/src/Core/HubSpotAction.cs
@@ -1,4 +1,4 @@
-﻿namespace Skarp.HubSpotClient.Core
+namespace Skarp.HubSpotClient.Core
 {
     /// <summary>
     /// Enumerates the possible actions against the hubspot api
@@ -25,6 +25,8 @@
 
         UpdateBatch,
 
-        ReadBatch
+        ReadBatch,
+
+        Lists
     }
 }

--- a/src/ListOfContacts/Dto/ListOfContactListsHubSpotEntity.cs
+++ b/src/ListOfContacts/Dto/ListOfContactListsHubSpotEntity.cs
@@ -9,48 +9,69 @@ namespace Skarp.HubSpotClient.ListOfContacts.Dto
 {
     public class ListOfContactListsHubSpotEntity: IHubSpotEntity
     {
-        [DataContract]
-        public class MetaData
+        [DataContract(Name="MetaData"]
+        public class ContactListsMetaData
         {
-            public string processing { get; set; }
-            public int size { get; set; }
-            public string error { get; set; }
-            public DateTime lastProcessingStateChangeAt { get; set; }
-            public DateTime lastSizeChangeAt { get; set; }
+            [DataMember(Name="processing")]
+            public string Processing { get; set; }
+            [DataMember(Name="size")]
+            public int Size { get; set; }
+            [DataMember(Name="error")]
+            public string Error { get; set; }
+            [DataMember(Name="lastProcessingStateChangeAt")]
+            public DateTime LastProcessingStateChangeAt { get; set; }
+            [DataMember(Name="lastSizeChangeAt")]
+            public DateTime LastSizeChangeAt { get; set; }
         }
 
-        [DataContract]
-        public class List
+        [DataContract(Name="List")]
+        public class ContactListsItem
         {
-            public bool dynamic { get; set; }
-            public MetaData metaData { get; set; }
-            public string name { get; set; }
-            public List<List<filter>> filters { get; set; }
-            public int portalId { get; set; }
-            public DateTime createdAt { get; set; }
-            public int listId { get; set; }
-            public DateTime updatedAt { get; set; }
-            public string listType { get; set; }
-            public int internalListId { get; set; }
-            public bool deleteable { get; set; }
+            [DataMember(Name="dynamic")]
+            public bool Dynamic { get; set; }
+            [DataMember(Name="metaData")]  
+            public ContactListsMetaData MetaData { get; set; }
+            [DataMember(Name="name")]  
+            public string Name { get; set; }
+            [DataMember(Name="filters")] 
+            public List<List<ContactListsFilter>> Filters { get; set; }
+            [DataMember(Name="portalId")] 
+            public int PortalId { get; set; }
+            [DataMember(Name="createdAt")] 
+            public DateTime CreatedAt { get; set; }
+            [DataMember(Name="listId")] 
+            public int ListId { get; set; }
+            [DataMember(Name="updatedAt")] 
+            public DateTime UpdatedAt { get; set; }
+            [DataMember(Name="listType")] 
+            public string ListType { get; set; }
+            [DataMember(Name="internalListId")] 
+            public int InternalListId { get; set; }
+            [DataMember(Name="deleteable")] 
+            public bool Deleteable { get; set; }
         }
 
-        [DataContract]
-        public class filter
+        [DataContract(Name="filter"]
+        public class ContactListsFilter
          {
-            public string filterFamily { get; set; }
-            public string withinTimeMode { get; set; }
-            public bool checkPastVersions { get; set; }
-            public string type { get; set; }
-            public string property { get; set; }
-            public string value { get; set; }
-
+            [DataMember(Name="filterFamily")] 
+            public string FilterFamily { get; set; }
+            [DataMember(Name="withinTimeMode")] 
+            public string WithinTimeMode { get; set; }
+            [DataMember(Name="checkPastVersions")] 
+            public bool CheckPastVersions { get; set; }
+            [DataMember(Name="type")] 
+            public string Type { get; set; }
+            [DataMember(Name="property")] 
+            public string Property { get; set; }
+            [DataMember(Name="value")] 
+            public string Value { get; set; }
             [DataMember(Name = "operator")]
             public string op { get; set; }
         }
 
 
-        public List<List> lists { get; set; }
+        public List<ContactListsItem> lists { get; set; }
         public int offset { get; set; }
 
         [DataMember(Name = "has-more")]

--- a/src/ListOfContacts/Dto/ListOfContactListsHubSpotEntity.cs
+++ b/src/ListOfContacts/Dto/ListOfContactListsHubSpotEntity.cs
@@ -9,7 +9,7 @@ namespace Skarp.HubSpotClient.ListOfContacts.Dto
 {
     public class ListOfContactListsHubSpotEntity: IHubSpotEntity
     {
-        [DataContract(Name="MetaData"]
+        [DataContract(Name="MetaData")]
         public class ContactListsMetaData
         {
             [DataMember(Name="processing")]
@@ -51,7 +51,7 @@ namespace Skarp.HubSpotClient.ListOfContacts.Dto
             public bool Deleteable { get; set; }
         }
 
-        [DataContract(Name="filter"]
+        [DataContract(Name="filter")]
         public class ContactListsFilter
          {
             [DataMember(Name="filterFamily")] 

--- a/src/ListOfContacts/Dto/ListOfContactListsHubSpotEntity.cs
+++ b/src/ListOfContacts/Dto/ListOfContactListsHubSpotEntity.cs
@@ -1,0 +1,71 @@
+﻿using Newtonsoft.Json;
+using Skarp.HubSpotClient.Core.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Skarp.HubSpotClient.ListOfContacts.Dto
+{
+    public class ListOfContactListsHubSpotEntity: IHubSpotEntity
+    {
+        [DataContract]
+        public class MetaData
+        {
+            public string processing { get; set; }
+            public int size { get; set; }
+            public string error { get; set; }
+            public DateTime lastProcessingStateChangeAt { get; set; }
+            public DateTime lastSizeChangeAt { get; set; }
+        }
+
+        [DataContract]
+        public class List
+        {
+            public bool dynamic { get; set; }
+            public MetaData metaData { get; set; }
+            public string name { get; set; }
+            public List<List<filter>> filters { get; set; }
+            public int portalId { get; set; }
+            public DateTime createdAt { get; set; }
+            public int listId { get; set; }
+            public DateTime updatedAt { get; set; }
+            public string listType { get; set; }
+            public int internalListId { get; set; }
+            public bool deleteable { get; set; }
+        }
+
+        [DataContract]
+        public class filter
+         {
+            public string filterFamily { get; set; }
+            public string withinTimeMode { get; set; }
+            public bool checkPastVersions { get; set; }
+            public string type { get; set; }
+            public string property { get; set; }
+            public string value { get; set; }
+
+            [DataMember(Name = "operator")]
+            public string op { get; set; }
+        }
+
+
+        public List<List> lists { get; set; }
+        public int offset { get; set; }
+
+        [DataMember(Name = "has-more")]
+        public bool HasMore { get; set; }
+
+        public bool IsNameValue => false;
+
+        public virtual void ToHubSpotDataEntity(ref dynamic dataEntity)
+        {
+
+        }
+
+        public virtual void FromHubSpotDataEntity(dynamic hubspotData)
+        {
+
+        }
+    }
+}

--- a/src/ListOfContacts/Dto/ListOfContactListsHubSpotEntity.cs
+++ b/src/ListOfContacts/Dto/ListOfContactListsHubSpotEntity.cs
@@ -19,9 +19,9 @@ namespace Skarp.HubSpotClient.ListOfContacts.Dto
             [DataMember(Name="error")]
             public string Error { get; set; }
             [DataMember(Name="lastProcessingStateChangeAt")]
-            public DateTime LastProcessingStateChangeAt { get; set; }
+            public string LastProcessingStateChangeAt { get; set; }
             [DataMember(Name="lastSizeChangeAt")]
-            public DateTime LastSizeChangeAt { get; set; }
+            public string LastSizeChangeAt { get; set; }
         }
 
         [DataContract(Name="List")]
@@ -38,11 +38,11 @@ namespace Skarp.HubSpotClient.ListOfContacts.Dto
             [DataMember(Name="portalId")] 
             public int PortalId { get; set; }
             [DataMember(Name="createdAt")] 
-            public DateTime CreatedAt { get; set; }
+            public string CreatedAt { get; set; }
             [DataMember(Name="listId")] 
             public int ListId { get; set; }
             [DataMember(Name="updatedAt")] 
-            public DateTime UpdatedAt { get; set; }
+            public string UpdatedAt { get; set; }
             [DataMember(Name="listType")] 
             public string ListType { get; set; }
             [DataMember(Name="internalListId")] 

--- a/src/ListOfContacts/Dto/ListOfContactListsHubSpotEntity.cs
+++ b/src/ListOfContacts/Dto/ListOfContactListsHubSpotEntity.cs
@@ -19,9 +19,9 @@ namespace Skarp.HubSpotClient.ListOfContacts.Dto
             [DataMember(Name="error")]
             public string Error { get; set; }
             [DataMember(Name="lastProcessingStateChangeAt")]
-            public string LastProcessingStateChangeAt { get; set; }
+            public long LastProcessingStateChangeAtTimeStamp { get; set; }
             [DataMember(Name="lastSizeChangeAt")]
-            public string LastSizeChangeAt { get; set; }
+            public long LastSizeChangeAtTimeStamp { get; set; }
         }
 
         [DataContract(Name="List")]
@@ -38,11 +38,11 @@ namespace Skarp.HubSpotClient.ListOfContacts.Dto
             [DataMember(Name="portalId")] 
             public int PortalId { get; set; }
             [DataMember(Name="createdAt")] 
-            public string CreatedAt { get; set; }
+            public long CreatedAtTimeStamp { get; set; }
             [DataMember(Name="listId")] 
             public int ListId { get; set; }
             [DataMember(Name="updatedAt")] 
-            public string UpdatedAt { get; set; }
+            public long UpdatedAtTimeStamp { get; set; }
             [DataMember(Name="listType")] 
             public string ListType { get; set; }
             [DataMember(Name="internalListId")] 

--- a/src/ListOfContacts/HubSpotListOfContactsClient.cs
+++ b/src/ListOfContacts/HubSpotListOfContactsClient.cs
@@ -74,6 +74,28 @@ namespace Skarp.HubSpotClient.ListOfContacts
         }
 
         /// <summary>
+        /// Return a list of contact lists from hubspot
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public async Task<T> GetListAsync<T>(ListOfContactListsRequestOptions opts = null)
+        {
+            Logger.LogDebug("Get list of contact lists");
+            if (opts == null)
+            {
+                opts = new ListOfContactListsRequestOptions();
+            }
+            var path = PathResolver(new ContactHubSpotEntity(), HubSpotAction.Lists)
+                .SetQueryParam("count", opts.NumberOfContactListsToReturn);
+            if (opts.ContactListOffset.HasValue)
+            {
+                path = path.SetQueryParam("vidOffset", opts.ContactListOffset);
+            }
+            var data = await GetGenericAsync<T>(path);
+            return data;
+        }
+
+        /// <summary>
         /// Add list of contacts based on list id
         /// </summary>
         /// <typeparam name="T"></typeparam>
@@ -116,6 +138,8 @@ namespace Skarp.HubSpotClient.ListOfContacts
             {
                 case HubSpotAction.Get:
                     return $"{entity.RouteBasePath}/lists/:listId:/contacts/all";
+                case HubSpotAction.Lists:
+                    return $"{entity.RouteBasePath}/lists";
                 case HubSpotAction.CreateBatch:
                     return $"{entity.RouteBasePath}/lists/:listId:/add";
                 case HubSpotAction.DeleteBatch:

--- a/src/ListOfContacts/ListOfContactListsRequestOptions.cs
+++ b/src/ListOfContacts/ListOfContactListsRequestOptions.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace Skarp.HubSpotClient.ListOfContacts
+{
+    public class ListOfContactListsRequestOptions
+    {
+        private int _numberOfContactListsToReturn = 100;
+
+        /// <summary>
+        /// Gets or sets the number of contact lists to return.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to 20 which is also the hubspot api default. Max value is 100
+        /// </remarks>
+        /// <value>
+        /// The number of contacts to return.
+        /// </value>
+        public int NumberOfContactListsToReturn
+        {
+            get => _numberOfContactListsToReturn;
+            set
+            {
+                if (value < 1 || value > 250)
+                {
+                    throw new ArgumentException(
+                        $"Number of contacts to return must be a positive ingeteger greater than 0 and less than 251 - you provided {value}");
+                }
+                _numberOfContactListsToReturn = value;
+            }
+        }
+
+        /// <summary>
+        /// Get or set the continuation offset when calling list many times to enumerate all your contact lists
+        /// </summary>
+        /// <remarks>
+        /// The return DTO from List contains the current "offset" that you can inject into your next list call 
+        /// to continue the listing process
+        /// </remarks>
+        public long? ContactListOffset { get; set; } = null;
+    }
+}


### PR DESCRIPTION
To request a contact list prior to this change it was necessary to know the list's listId. This change enables the API user to discover which lists are available - the information it returns about each list does not include the lists' contents but it does include their names and listIds along with other information about each of the lists.

This is the functionality that this change implements:
https://legacydocs.hubspot.com/docs/methods/lists/get_lists

Closes #62 