### PR TITLE
🔧 Enable SourceLink

### DIFF
--- a/src/hubspot-client.csproj
+++ b/src/hubspot-client.csproj
@@ -15,8 +15,18 @@
     <RepositoryUrl>https://github.com/skarpdev/dotnetcore-hubspot-client/</RepositoryUrl>
     <PackageId>HubSpotClient</PackageId>
     <Company>SKARP ApS</Company>
+    
+    <!-- Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+
+    <!-- Embed source files that are not tracked by the source control manager in the PDB -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+
+    <!-- Recommended: Embed symbols containing Source Link in the main file (exe/dll) -->
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
     <PackageReference Include="flurl" Version="3.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
@@ -31,4 +41,7 @@
     </AssemblyAttribute>
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(APPVEYOR)' == 'True'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
After updating to the latest version of the Nuget, I encountered what seems to be a bug. I wanted to debug into the library and realized that it would be useful to enable source link so developers can step through the library while debugging.

I followed the steps from this article:

https://devblogs.microsoft.com/dotnet/producing-packages-with-source-link/
