### PR TITLE
In light of private apps requirement, modified code to support Bearer token authentication

### DIFF
--- a/src/Associations/HubSpotAssociationsClient.cs
+++ b/src/Associations/HubSpotAssociationsClient.cs
@@ -21,14 +21,14 @@ namespace Skarp.HubSpotClient.Associations
         /// <param name="logger"></param>
         /// <param name="serializer"></param>
         /// <param name="hubSpotBaseUrl"></param>
-        /// <param name="apiKey"></param>
+        /// <param name="apiToken"></param>
         public HubSpotAssociationsClient(
             IRapidHttpClient httpClient,
             ILogger logger,
             RequestSerializer serializer,
             string hubSpotBaseUrl,
-            string apiKey)
-             : base(httpClient, logger, serializer, hubSpotBaseUrl, apiKey)
+            string apiToken)
+             : base(httpClient, logger, serializer, hubSpotBaseUrl, apiToken)
         {
         }
 
@@ -40,14 +40,14 @@ namespace Skarp.HubSpotClient.Associations
         /// via the network - if you wish to have support for functional tests and mocking use the "eager" constructor
         /// that takes in all underlying dependecies
         /// </remarks>
-        /// <param name="apiKey">Your API key</param>
-        public HubSpotAssociationsClient(string apiKey)
+        /// <param name="apiToken">Your API token</param>
+        public HubSpotAssociationsClient(string apiToken)
         : base(
               new RealRapidHttpClient(new HttpClient()),
               NoopLoggerFactory.Get(),
               new RequestSerializer(new RequestDataConverter(NoopLoggerFactory.Get<RequestDataConverter>())),
               "https://api.hubapi.com",
-              apiKey)
+              apiToken)
         { }
 
         /// <summary>

--- a/src/Company/HubSpotCompanyClient.cs
+++ b/src/Company/HubSpotCompanyClient.cs
@@ -5,8 +5,6 @@ using System.Threading.Tasks;
 using Flurl;
 using Microsoft.Extensions.Logging;
 using RapidCore.Network;
-using Skarp.HubSpotClient.Common.Dto.Properties;
-using Skarp.HubSpotClient.Common.Interfaces;
 using Skarp.HubSpotClient.Company.Dto;
 using Skarp.HubSpotClient.Company.Interfaces;
 using Skarp.HubSpotClient.Core;
@@ -24,14 +22,14 @@ namespace Skarp.HubSpotClient.Company
         /// <param name="logger"></param>
         /// <param name="serializer"></param>
         /// <param name="hubSpotBaseUrl"></param>
-        /// <param name="apiKey"></param>
+        /// <param name="apiToken"></param>
         public HubSpotCompanyClient(
             IRapidHttpClient httpClient,
             ILogger<HubSpotCompanyClient> logger,
             RequestSerializer serializer,
             string hubSpotBaseUrl,
-            string apiKey)
-            : base(httpClient, logger, serializer, hubSpotBaseUrl, apiKey)
+            string apiToken)
+            : base(httpClient, logger, serializer, hubSpotBaseUrl, apiToken)
         {
         }
 
@@ -43,14 +41,14 @@ namespace Skarp.HubSpotClient.Company
         /// via the network - if you wish to have support for functional tests and mocking use the "eager" constructor
         /// that takes in all underlying dependecies
         /// </remarks>
-        /// <param name="apiKey">Your API key</param>
-        public HubSpotCompanyClient(string apiKey)
+        /// <param name="apiToken">Your API token</param>
+        public HubSpotCompanyClient(string apiToken)
         : base(
               new RealRapidHttpClient(new HttpClient()),
               NoopLoggerFactory.Get(),
               new RequestSerializer(new RequestDataConverter(NoopLoggerFactory.Get<RequestDataConverter>())),
               "https://api.hubapi.com",
-              apiKey)
+              apiToken)
         { }
 
         /// <summary>

--- a/src/Contact/HubSpotContactClient.cs
+++ b/src/Contact/HubSpotContactClient.cs
@@ -23,14 +23,14 @@ namespace Skarp.HubSpotClient.Contact
         /// <param name="logger"></param>
         /// <param name="serializer"></param>
         /// <param name="hubSpotBaseUrl"></param>
-        /// <param name="apiKey"></param>
+        /// <param name="apiToken"></param>
         public HubSpotContactClient(
             IRapidHttpClient httpClient,
             ILogger<HubSpotContactClient> logger,
             RequestSerializer serializer,
             string hubSpotBaseUrl,
-            string apiKey)
-            : base(httpClient, logger, serializer, hubSpotBaseUrl, apiKey)
+            string apiToken)
+            : base(httpClient, logger, serializer, hubSpotBaseUrl, apiToken)
         {
         }
 
@@ -42,14 +42,14 @@ namespace Skarp.HubSpotClient.Contact
         /// via the network - if you wish to have support for functional tests and mocking use the "eager" constructor
         /// that takes in all underlying dependecies
         /// </remarks>
-        /// <param name="apiKey">Your API key</param>
-        public HubSpotContactClient(string apiKey)
+        /// <param name="apiToken">Your API token</param>
+        public HubSpotContactClient(string apiToken)
         : base(
               new RealRapidHttpClient(new HttpClient()),
               NoopLoggerFactory.Get(),
               new RequestSerializer(new RequestDataConverter(NoopLoggerFactory.Get<RequestDataConverter>())),
               "https://api.hubapi.com",
-              apiKey)
+              apiToken)
         { }
 
         /// <summary>

--- a/src/Deal/HubSpotDealClient.cs
+++ b/src/Deal/HubSpotDealClient.cs
@@ -23,14 +23,14 @@ namespace Skarp.HubSpotClient.Deal
         /// <param name="logger"></param>
         /// <param name="serializer"></param>
         /// <param name="hubSpotBaseUrl"></param>
-        /// <param name="apiKey"></param>
+        /// <param name="apiToken"></param>
         public HubSpotDealClient(
             IRapidHttpClient httpClient,
             ILogger<HubSpotDealClient> logger,
             RequestSerializer serializer,
             string hubSpotBaseUrl,
-            string apiKey)
-            : base(httpClient, logger, serializer, hubSpotBaseUrl, apiKey)
+            string apiToken)
+            : base(httpClient, logger, serializer, hubSpotBaseUrl, apiToken)
         {
         }
 
@@ -42,14 +42,14 @@ namespace Skarp.HubSpotClient.Deal
         /// via the network - if you wish to have support for functional tests and mocking use the "eager" constructor
         /// that takes in all underlying dependecies
         /// </remarks>
-        /// <param name="apiKey">Your API key</param>
-        public HubSpotDealClient(string apiKey)
+        /// <param name="apiToken">Your API token</param>
+        public HubSpotDealClient(string apiToken)
         : base(
               new RealRapidHttpClient(new HttpClient()),
               NoopLoggerFactory.Get(),
               new RequestSerializer(new RequestDataConverter(NoopLoggerFactory.Get<RequestDataConverter>())),
               "https://api.hubapi.com",
-              apiKey)
+              apiToken)
         { }
 
         /// <summary>

--- a/src/LineItem/HubSpotLineItemClient.cs
+++ b/src/LineItem/HubSpotLineItemClient.cs
@@ -23,14 +23,14 @@ namespace Skarp.HubSpotClient.LineItem
         /// <param name="logger"></param>
         /// <param name="serializer"></param>
         /// <param name="hubSpotBaseUrl"></param>
-        /// <param name="apiKey"></param>
+        /// <param name="apiToken"></param>
         public HubSpotLineItemClient(
             IRapidHttpClient httpClient,
             ILogger<HubSpotLineItemClient> logger,
             RequestSerializer serializer,
             string hubSpotBaseUrl,
-            string apiKey)
-            : base(httpClient, logger, serializer, hubSpotBaseUrl, apiKey)
+            string apiToken)
+            : base(httpClient, logger, serializer, hubSpotBaseUrl, apiToken)
         {
         }
 
@@ -42,14 +42,14 @@ namespace Skarp.HubSpotClient.LineItem
         /// via the network - if you wish to have support for functional tests and mocking use the "eager" constructor
         /// that takes in all underlying dependecies
         /// </remarks>
-        /// <param name="apiKey">Your API key</param>
-        public HubSpotLineItemClient(string apiKey)
+        /// <param name="apiToken">Your API token</param>
+        public HubSpotLineItemClient(string apiToken)
         : base(
               new RealRapidHttpClient(new HttpClient()),
               NoopLoggerFactory.Get(),
               new RequestSerializer(new RequestDataConverter(NoopLoggerFactory.Get<RequestDataConverter>())),
               "https://api.hubapi.com",
-              apiKey)
+              apiToken)
         { }
 
         public Task<T> CreateAsync<T>(ILineItemHubSpotEntity entity) where T : IHubSpotEntity, new()

--- a/src/ListOfContacts/HubSpotListOfContactsClient.cs
+++ b/src/ListOfContacts/HubSpotListOfContactsClient.cs
@@ -22,14 +22,14 @@ namespace Skarp.HubSpotClient.ListOfContacts
         /// <param name="logger"></param>
         /// <param name="serializer"></param>
         /// <param name="hubSpotBaseUrl"></param>
-        /// <param name="apiKey"></param>
+        /// <param name="apiToken"></param>
         public HubSpotListOfContactsClient(
             IRapidHttpClient httpClient,
             ILogger<HubSpotListOfContactsClient> logger,
             RequestSerializer serializer,
             string hubSpotBaseUrl,
-            string apiKey)
-            : base(httpClient, logger, serializer, hubSpotBaseUrl, apiKey)
+            string apiToken)
+            : base(httpClient, logger, serializer, hubSpotBaseUrl, apiToken)
         {
         }
 
@@ -41,14 +41,14 @@ namespace Skarp.HubSpotClient.ListOfContacts
         /// via the network - if you wish to have support for functional tests and mocking use the "eager" constructor
         /// that takes in all underlying dependecies
         /// </remarks>
-        /// <param name="apiKey">Your API key</param>
-        public HubSpotListOfContactsClient(string apiKey)
+        /// <param name="apiToken">Your API token</param>
+        public HubSpotListOfContactsClient(string apiToken)
         : base(
               new RealRapidHttpClient(new HttpClient()),
               NoopLoggerFactory.Get(),
               new RequestSerializer(new RequestDataConverter(NoopLoggerFactory.Get<RequestDataConverter>())),
               "https://api.hubapi.com",
-              apiKey)
+              apiToken)
         { }
 
 

--- a/src/Owner/HubSpotOwnerClient.cs
+++ b/src/Owner/HubSpotOwnerClient.cs
@@ -21,14 +21,14 @@ namespace Skarp.HubSpotClient.Owner
         /// <param name="logger"></param>
         /// <param name="serializer"></param>
         /// <param name="hubSpotBaseUrl"></param>
-        /// <param name="apiKey"></param>
+        /// <param name="apiToken"></param>
         public HubSpotOwnerClient(
             IRapidHttpClient httpClient,
             ILogger<HubSpotOwnerClient> logger,
             RequestSerializer serializer,
             string hubSpotBaseUrl,
-            string apiKey)
-            : base(httpClient, logger, serializer, hubSpotBaseUrl, apiKey)
+            string apiToken)
+            : base(httpClient, logger, serializer, hubSpotBaseUrl, apiToken)
         {
         }
 
@@ -38,16 +38,16 @@ namespace Skarp.HubSpotClient.Owner
         /// <remarks>
         /// This constructor creates a HubSpotOwnerClient using "real" dependencies that will send requests 
         /// via the network - if you wish to have support for functional tests and mocking use the "eager" constructor
-        /// that takes in all underlying dependecies
+        /// that takes in all underlying dependencies
         /// </remarks>
-        /// <param name="apiKey">Your API key</param>
-        public HubSpotOwnerClient(string apiKey)
+        /// <param name="apiToken">Your API token</param>
+        public HubSpotOwnerClient(string apiToken)
         : base(
               new RealRapidHttpClient(new HttpClient()),
               NoopLoggerFactory.Get(),
               new RequestSerializer(new RequestDataConverter(NoopLoggerFactory.Get<RequestDataConverter>())),
               "https://api.hubapi.com",
-              apiKey)
+              apiToken)
         { }
 
         /// <summary>


### PR DESCRIPTION
Modified as per HubSpot requirement. From their announcement:

_"On June 1, 2022, we published a changelog update and Community blog post announcing an important change to API Keys. With this change, you’ll need to migrate existing integrations from using HubSpot API Key authentication to Private Apps by November 30, 2022."_



