### PR TITLE
chore: prepare tests for bearer token auth

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,8 @@ image: Visual Studio 2022
 environment:
   HUBSPOT_API_KEY:
     secure: nEkpqjqVe4G73k8gkmpYndR8GGQdK58k98IxzWwoZS4Rvq+bTOR9Yok2ISgjjNWr
+  HUBSPOT_API_TOKEN:
+    secure: nWXtqDplY3BMELyLFkxVlKcMECU4+rs9sJuWaNkFbHik3n9VOeRGPLOGsUN3UMAz
 pull_requests:
   do_not_increment_build_number: true
 branches:

--- a/test/integration/Company/HubSpotCompanyClientIntegrationTest.cs
+++ b/test/integration/Company/HubSpotCompanyClientIntegrationTest.cs
@@ -21,7 +21,7 @@ namespace integration.Company
 
         public HubSpotCompanyClientIntegrationTest(ITestOutputHelper output) : base(output)
         {
-            _apiKey = Environment.GetEnvironmentVariable("HUBSPOT_API_KEY") ?? "demo";
+            _apiKey = Environment.GetEnvironmentVariable("HUBSPOT_API_KEY") ?? Environment.GetEnvironmentVariable("HUBSPOT_API_TOKEN") ?? "demo";
             _isAppVeyorEnv = (Environment.GetEnvironmentVariable("APPVEYOR") ?? "false").Equals("true", StringComparison.InvariantCultureIgnoreCase);
 ;            _client = new HubSpotCompanyClient(
                 new RealRapidHttpClient(new HttpClient()),

--- a/test/integration/Contact/HubSpotContactClientIntegrationTest.cs
+++ b/test/integration/Contact/HubSpotContactClientIntegrationTest.cs
@@ -22,7 +22,7 @@ namespace integration.Contact
 
         public HubSpotContactClientIntegrationTest(ITestOutputHelper output) : base(output)
         {
-            _apiKey = Environment.GetEnvironmentVariable("HUBSPOT_API_KEY") ?? "demo";
+            _apiKey = Environment.GetEnvironmentVariable("HUBSPOT_API_KEY") ?? Environment.GetEnvironmentVariable("HUBSPOT_API_TOKEN") ?? "demo";
             _isAppVeyorEnv = (Environment.GetEnvironmentVariable("APPVEYOR") ?? "false").Equals("true", StringComparison.InvariantCultureIgnoreCase);
 ;            _client = new HubSpotContactClient(
                 new RealRapidHttpClient(new HttpClient()),

--- a/test/integration/Deal/HubSpotDealClientIntegrationTest.cs
+++ b/test/integration/Deal/HubSpotDealClientIntegrationTest.cs
@@ -21,7 +21,7 @@ namespace integration.Deal
 
         public HubSpotDealClientIntegrationTest(ITestOutputHelper output) : base(output)
         {
-            _apiKey = Environment.GetEnvironmentVariable("HUBSPOT_API_KEY") ?? "demo";
+            _apiKey = Environment.GetEnvironmentVariable("HUBSPOT_API_KEY") ?? Environment.GetEnvironmentVariable("HUBSPOT_API_TOKEN") ?? "demo";
             _isAppVeyorEnv = (Environment.GetEnvironmentVariable("APPVEYOR") ?? "false").Equals("true", StringComparison.InvariantCultureIgnoreCase);
 ;            _client = new HubSpotDealClient(
                 new RealRapidHttpClient(new HttpClient()),


### PR DESCRIPTION
Due to #92 and #93 we need to support the new Private Apps and new Bearer auth.

This PR adds a new `pat` access token and the integration tests have been updated to try and read either  `HUBSPOT_API_KEY` or `HUBSPOT_API_TOKEN` to provide these to the clients.