### PR TITLE
feat: private access token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ public class ContactTest
   [Fact]
   public async Task Getting_contacts_work()
   {
-    var client = new HubSpotContactClient("my-awesome-api-key");
+    var client = new HubSpotContactClient("my-awesome-api-key-or-pat");
     var contact = await client.GetByEmailAsync<ContactHubSpotEntity>("adrian@hubspot.com");
     Assert.NotNull(contact); // victory!
   }
@@ -91,7 +91,7 @@ public class CompanyTest
   [Fact]
   public async Task Getting_company_works()
   {
-    var client = new HubSpotCompanyClient("my-awesome-api-key");
+    var client = new HubSpotCompanyClient("my-awesome-api-key-or-pat");
     var company = await client.GetByIdAsync<CompanyHubSpotEntity>(42L);
     Assert.NotNull(company); // victory!
   }
@@ -121,7 +121,7 @@ public class OwnerTest
   [Fact]
   public async Task Getting_owner_works()
   {
-    var client = new HubSpotLineItemClient("my-awesome-api-key");
+    var client = new HubSpotLineItemClient("my-awesome-api-key-or-pat");
     var lineItem = await client.GetByIdAsync<LineItemHubSpotEntity>(42L);
     Assert.NotNull(lineItem); // victory!
   }
@@ -145,7 +145,7 @@ public class OwnerTest
   [Fact]
   public async Task Getting_owner_works()
   {
-    var client = new HubSpotOwnerClient("my-awesome-api-key");
+    var client = new HubSpotOwnerClient("my-awesome-api-key-or-pat");
     var owner = await client.GetByIdAsync<OwnerHubSpotEntity>(42L);
     Assert.NotNull(owner); // victory!
   }

--- a/src/Associations/HubSpotAssociationsClient.cs
+++ b/src/Associations/HubSpotAssociationsClient.cs
@@ -21,14 +21,14 @@ namespace Skarp.HubSpotClient.Associations
         /// <param name="logger"></param>
         /// <param name="serializer"></param>
         /// <param name="hubSpotBaseUrl"></param>
-        /// <param name="apiKey"></param>
+        /// <param name="apiKeyOrToken"></param>
         public HubSpotAssociationsClient(
             IRapidHttpClient httpClient,
             ILogger logger,
             RequestSerializer serializer,
             string hubSpotBaseUrl,
-            string apiKey)
-             : base(httpClient, logger, serializer, hubSpotBaseUrl, apiKey)
+            string apiKeyOrToken
+            ) : base(httpClient, logger, serializer, hubSpotBaseUrl, apiKeyOrToken)
         {
         }
 
@@ -40,14 +40,14 @@ namespace Skarp.HubSpotClient.Associations
         /// via the network - if you wish to have support for functional tests and mocking use the "eager" constructor
         /// that takes in all underlying dependecies
         /// </remarks>
-        /// <param name="apiKey">Your API key</param>
-        public HubSpotAssociationsClient(string apiKey)
+        /// <param name="apiKeyOrToken">Your API token</param>
+        public HubSpotAssociationsClient(string apiKeyOrToken)
         : base(
               new RealRapidHttpClient(new HttpClient()),
               NoopLoggerFactory.Get(),
               new RequestSerializer(new RequestDataConverter(NoopLoggerFactory.Get<RequestDataConverter>())),
               "https://api.hubapi.com",
-              apiKey)
+              apiKeyOrToken)
         { }
 
         /// <summary>

--- a/src/Company/HubSpotCompanyClient.cs
+++ b/src/Company/HubSpotCompanyClient.cs
@@ -5,8 +5,6 @@ using System.Threading.Tasks;
 using Flurl;
 using Microsoft.Extensions.Logging;
 using RapidCore.Network;
-using Skarp.HubSpotClient.Common.Dto.Properties;
-using Skarp.HubSpotClient.Common.Interfaces;
 using Skarp.HubSpotClient.Company.Dto;
 using Skarp.HubSpotClient.Company.Interfaces;
 using Skarp.HubSpotClient.Core;
@@ -24,14 +22,14 @@ namespace Skarp.HubSpotClient.Company
         /// <param name="logger"></param>
         /// <param name="serializer"></param>
         /// <param name="hubSpotBaseUrl"></param>
-        /// <param name="apiKey"></param>
+        /// <param name="apiKeyOrToken"></param>
         public HubSpotCompanyClient(
             IRapidHttpClient httpClient,
             ILogger<HubSpotCompanyClient> logger,
             RequestSerializer serializer,
             string hubSpotBaseUrl,
-            string apiKey)
-            : base(httpClient, logger, serializer, hubSpotBaseUrl, apiKey)
+            string apiKeyOrToken
+        ) : base(httpClient, logger, serializer, hubSpotBaseUrl, apiKeyOrToken)
         {
         }
 
@@ -43,14 +41,15 @@ namespace Skarp.HubSpotClient.Company
         /// via the network - if you wish to have support for functional tests and mocking use the "eager" constructor
         /// that takes in all underlying dependecies
         /// </remarks>
-        /// <param name="apiKey">Your API key</param>
-        public HubSpotCompanyClient(string apiKey)
+        /// <param name="apiKeyOrToken">Your API token</param>
+        public HubSpotCompanyClient(string apiKeyOrToken)
         : base(
               new RealRapidHttpClient(new HttpClient()),
               NoopLoggerFactory.Get(),
               new RequestSerializer(new RequestDataConverter(NoopLoggerFactory.Get<RequestDataConverter>())),
               "https://api.hubapi.com",
-              apiKey)
+              apiKeyOrToken
+        )
         { }
 
         /// <summary>

--- a/src/Contact/HubSpotContactClient.cs
+++ b/src/Contact/HubSpotContactClient.cs
@@ -23,14 +23,14 @@ namespace Skarp.HubSpotClient.Contact
         /// <param name="logger"></param>
         /// <param name="serializer"></param>
         /// <param name="hubSpotBaseUrl"></param>
-        /// <param name="apiKey"></param>
+        /// <param name="apiKeyOrToken"></param>
         public HubSpotContactClient(
             IRapidHttpClient httpClient,
             ILogger<HubSpotContactClient> logger,
             RequestSerializer serializer,
             string hubSpotBaseUrl,
-            string apiKey)
-            : base(httpClient, logger, serializer, hubSpotBaseUrl, apiKey)
+            string apiKeyOrToken
+        ) : base(httpClient, logger, serializer, hubSpotBaseUrl, apiKeyOrToken)
         {
         }
 
@@ -42,14 +42,15 @@ namespace Skarp.HubSpotClient.Contact
         /// via the network - if you wish to have support for functional tests and mocking use the "eager" constructor
         /// that takes in all underlying dependecies
         /// </remarks>
-        /// <param name="apiKey">Your API key</param>
-        public HubSpotContactClient(string apiKey)
+        /// <param name="apiKeyOrToken">Your API token</param>
+        public HubSpotContactClient(string apiKeyOrToken)
         : base(
               new RealRapidHttpClient(new HttpClient()),
               NoopLoggerFactory.Get(),
               new RequestSerializer(new RequestDataConverter(NoopLoggerFactory.Get<RequestDataConverter>())),
               "https://api.hubapi.com",
-              apiKey)
+              apiKeyOrToken
+        )
         { }
 
         /// <summary>

--- a/src/Deal/HubSpotDealClient.cs
+++ b/src/Deal/HubSpotDealClient.cs
@@ -23,14 +23,14 @@ namespace Skarp.HubSpotClient.Deal
         /// <param name="logger"></param>
         /// <param name="serializer"></param>
         /// <param name="hubSpotBaseUrl"></param>
-        /// <param name="apiKey"></param>
+        /// <param name="apiKeyOrToken"></param>
         public HubSpotDealClient(
             IRapidHttpClient httpClient,
             ILogger<HubSpotDealClient> logger,
             RequestSerializer serializer,
             string hubSpotBaseUrl,
-            string apiKey)
-            : base(httpClient, logger, serializer, hubSpotBaseUrl, apiKey)
+            string apiKeyOrToken
+        ) : base(httpClient, logger, serializer, hubSpotBaseUrl, apiKeyOrToken)
         {
         }
 
@@ -42,14 +42,14 @@ namespace Skarp.HubSpotClient.Deal
         /// via the network - if you wish to have support for functional tests and mocking use the "eager" constructor
         /// that takes in all underlying dependecies
         /// </remarks>
-        /// <param name="apiKey">Your API key</param>
-        public HubSpotDealClient(string apiKey)
+        /// <param name="apiKeyOrToken">Your API token</param>
+        public HubSpotDealClient(string apiKeyOrToken)
         : base(
               new RealRapidHttpClient(new HttpClient()),
               NoopLoggerFactory.Get(),
               new RequestSerializer(new RequestDataConverter(NoopLoggerFactory.Get<RequestDataConverter>())),
               "https://api.hubapi.com",
-              apiKey)
+              apiKeyOrToken)
         { }
 
         /// <summary>

--- a/src/LineItem/HubSpotLineItemClient.cs
+++ b/src/LineItem/HubSpotLineItemClient.cs
@@ -23,14 +23,14 @@ namespace Skarp.HubSpotClient.LineItem
         /// <param name="logger"></param>
         /// <param name="serializer"></param>
         /// <param name="hubSpotBaseUrl"></param>
-        /// <param name="apiKey"></param>
+        /// <param name="apiKeyOrToken"></param>
         public HubSpotLineItemClient(
             IRapidHttpClient httpClient,
             ILogger<HubSpotLineItemClient> logger,
             RequestSerializer serializer,
             string hubSpotBaseUrl,
-            string apiKey)
-            : base(httpClient, logger, serializer, hubSpotBaseUrl, apiKey)
+            string apiKeyOrToken
+        ) : base(httpClient, logger, serializer, hubSpotBaseUrl, apiKeyOrToken)
         {
         }
 
@@ -42,14 +42,14 @@ namespace Skarp.HubSpotClient.LineItem
         /// via the network - if you wish to have support for functional tests and mocking use the "eager" constructor
         /// that takes in all underlying dependecies
         /// </remarks>
-        /// <param name="apiKey">Your API key</param>
-        public HubSpotLineItemClient(string apiKey)
+        /// <param name="apiKeyOrToken">Your API token</param>
+        public HubSpotLineItemClient(string apiKeyOrToken)
         : base(
               new RealRapidHttpClient(new HttpClient()),
               NoopLoggerFactory.Get(),
               new RequestSerializer(new RequestDataConverter(NoopLoggerFactory.Get<RequestDataConverter>())),
               "https://api.hubapi.com",
-              apiKey)
+              apiKeyOrToken)
         { }
 
         public Task<T> CreateAsync<T>(ILineItemHubSpotEntity entity) where T : IHubSpotEntity, new()

--- a/src/ListOfContacts/HubSpotListOfContactsClient.cs
+++ b/src/ListOfContacts/HubSpotListOfContactsClient.cs
@@ -22,14 +22,14 @@ namespace Skarp.HubSpotClient.ListOfContacts
         /// <param name="logger"></param>
         /// <param name="serializer"></param>
         /// <param name="hubSpotBaseUrl"></param>
-        /// <param name="apiKey"></param>
+        /// <param name="apiKeyOrToken"></param>
         public HubSpotListOfContactsClient(
             IRapidHttpClient httpClient,
             ILogger<HubSpotListOfContactsClient> logger,
             RequestSerializer serializer,
             string hubSpotBaseUrl,
-            string apiKey)
-            : base(httpClient, logger, serializer, hubSpotBaseUrl, apiKey)
+            string apiKeyOrToken
+        ) : base(httpClient, logger, serializer, hubSpotBaseUrl, apiKeyOrToken)
         {
         }
 
@@ -41,14 +41,14 @@ namespace Skarp.HubSpotClient.ListOfContacts
         /// via the network - if you wish to have support for functional tests and mocking use the "eager" constructor
         /// that takes in all underlying dependecies
         /// </remarks>
-        /// <param name="apiKey">Your API key</param>
-        public HubSpotListOfContactsClient(string apiKey)
+        /// <param name="apiKeyOrToken">Your API token</param>
+        public HubSpotListOfContactsClient(string apiKeyOrToken)
         : base(
               new RealRapidHttpClient(new HttpClient()),
               NoopLoggerFactory.Get(),
               new RequestSerializer(new RequestDataConverter(NoopLoggerFactory.Get<RequestDataConverter>())),
               "https://api.hubapi.com",
-              apiKey)
+              apiKeyOrToken)
         { }
 
 

--- a/src/Owner/HubSpotOwnerClient.cs
+++ b/src/Owner/HubSpotOwnerClient.cs
@@ -21,14 +21,14 @@ namespace Skarp.HubSpotClient.Owner
         /// <param name="logger"></param>
         /// <param name="serializer"></param>
         /// <param name="hubSpotBaseUrl"></param>
-        /// <param name="apiKey"></param>
+        /// <param name="apiKeyOrToken"></param>
         public HubSpotOwnerClient(
             IRapidHttpClient httpClient,
             ILogger<HubSpotOwnerClient> logger,
             RequestSerializer serializer,
             string hubSpotBaseUrl,
-            string apiKey)
-            : base(httpClient, logger, serializer, hubSpotBaseUrl, apiKey)
+            string apiKeyOrToken
+        ) : base(httpClient, logger, serializer, hubSpotBaseUrl, apiKeyOrToken)
         {
         }
 
@@ -38,16 +38,16 @@ namespace Skarp.HubSpotClient.Owner
         /// <remarks>
         /// This constructor creates a HubSpotOwnerClient using "real" dependencies that will send requests 
         /// via the network - if you wish to have support for functional tests and mocking use the "eager" constructor
-        /// that takes in all underlying dependecies
+        /// that takes in all underlying dependencies
         /// </remarks>
-        /// <param name="apiKey">Your API key</param>
-        public HubSpotOwnerClient(string apiKey)
+        /// <param name="apiKeyOrToken">Your API token</param>
+        public HubSpotOwnerClient(string apiKeyOrToken)
         : base(
               new RealRapidHttpClient(new HttpClient()),
               NoopLoggerFactory.Get(),
               new RequestSerializer(new RequestDataConverter(NoopLoggerFactory.Get<RequestDataConverter>())),
               "https://api.hubapi.com",
-              apiKey)
+              apiKeyOrToken)
         { }
 
         /// <summary>


### PR DESCRIPTION
This PR supersedes #93 by incorporating the changes, but as a non breaking change as originally proposed on the PR.

Commit `dfcd93f31a11af6769b2adf1cc4b8586f19b982b` from @alexcrowdpharm has been cherry-picked from the fork, and I've updated the code-paths to retain support for the legacy `hapikey` for now.
